### PR TITLE
[FEAT] 메인 탭별 헤더 레이아웃 구현

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/MainActivity.kt
@@ -25,12 +25,7 @@ import java.util.*
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main, "MainActivity") {
 
     private val dishViewModel: DishViewModel by viewModels()
-    private val tabTitleArray = arrayOf(
-        TAB_EXHIBITION,
-        TAB_MAIN_DISH,
-        TAB_SOUP_DISH,
-        TAB_SIDE_DISH
-    )
+    private lateinit var tabTitleArray: Array<String>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,7 +34,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main, "
     }
 
     private fun initView() {
+        setTabTitleArray()
         setTabWithViewPager()
+    }
+
+    private fun setTabTitleArray() {
+        tabTitleArray = resources.getStringArray(R.array.main_tab_text)
     }
 
     private fun setTabWithViewPager() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,7 +34,8 @@
             app:tabMinWidth="140dp"
             app:tabMode="scrollable"
             app:tabSelectedTextColor="@color/grey_scale_black"
-            app:tabTextColor="@color/grey_scale_black" />
+            app:tabTextColor="@color/grey_scale_black"
+            app:tabTextAppearance="@style/tab_text"/>
 
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/main_vp"

--- a/app/src/main/res/layout/fragment_exhibition.xml
+++ b/app/src/main/res/layout/fragment_exhibition.xml
@@ -6,19 +6,78 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="exhibition"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:textSize="@dimen/text_size_24sp"/>
+            android:backgroundTint="@color/white">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="24dp"
+                    android:background="@color/primary_surface">
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/base_space_16dp"
+                        android:layout_marginTop="36dp"
+                        android:backgroundTint="@color/grey_scale_surface"
+                        app:cardElevation="0dp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:shapeAppearanceOverlay="@style/cardViewRadius"
+                        app:strokeColor="@color/grey_scale_black"
+                        app:strokeWidth="1dp">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:fontFamily="@font/noto_sans_kr_medium_500"
+                            android:gravity="center"
+                            android:includeFontPadding="false"
+                            android:paddingHorizontal="14dp"
+                            android:paddingVertical="5dp"
+                            android:text="기획전"
+                            android:textColor="@color/grey_scale_black"
+                            android:textSize="@dimen/text_size_10sp" />
+
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/base_space_16dp"
+                        android:layout_marginTop="70dp"
+                        android:layout_marginBottom="36dp"
+                        android:includeFontPadding="false"
+                        android:text="@string/main_header_exhibition"
+                        style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/exhibition_rv"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"/>
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_maindish.xml
+++ b/app/src/main/res/layout/fragment_maindish.xml
@@ -6,19 +6,76 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="maindish"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:textSize="@dimen/text_size_24sp"/>
+            android:backgroundTint="@color/white">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="24dp">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/maindish_cl_header_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@color/primary_surface"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/base_space_16dp"
+                            android:layout_marginTop="53dp"
+                            android:layout_marginBottom="53dp"
+                            android:text="@string/main_header_main_dish"
+                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/maindish_cl_header_filter"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="24dp"
+                        app:layout_constraintTop_toBottomOf="@id/maindish_cl_header_text">
+
+                        <ImageView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/base_space_16dp"
+                            android:src="@drawable/ic_item_grid"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:tint="@color/grey_scale_line" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/exhibition_rv"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_sidedish.xml
+++ b/app/src/main/res/layout/fragment_sidedish.xml
@@ -6,19 +6,77 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="sidedish"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:textSize="@dimen/text_size_24sp"/>
+            android:backgroundTint="@color/white">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="24dp">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/sidedish_cl_header_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@color/primary_surface"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/base_space_16dp"
+                            android:layout_marginTop="53dp"
+                            android:layout_marginBottom="53dp"
+                            android:text="@string/main_header_side_dish"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/maindish_cl_header_filter"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="24dp"
+                        app:layout_constraintTop_toBottomOf="@id/sidedish_cl_header_text">
+
+                        <TextView
+                            android:id="@+id/soupdish_tv_item_count"
+                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.Style"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/base_space_16dp"
+                            android:text="총 8개 상품"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/exhibition_rv"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_soupdish.xml
+++ b/app/src/main/res/layout/fragment_soupdish.xml
@@ -6,19 +6,77 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="soupdish"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:textSize="@dimen/text_size_24sp"/>
+            android:backgroundTint="@color/white">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="24dp">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/soupdish_cl_header_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@color/primary_surface"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/base_space_16dp"
+                            android:layout_marginTop="53dp"
+                            android:layout_marginBottom="53dp"
+                            android:text="@string/main_header_soup_dish"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/maindish_cl_header_filter"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="24dp"
+                        app:layout_constraintTop_toBottomOf="@id/soupdish_cl_header_text">
+
+                        <TextView
+                            android:id="@+id/soupdish_tv_item_count"
+                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.Style"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/base_space_16dp"
+                            android:text="총 8개 상품"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/exhibition_rv"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="main_tab_text">
+        <item>기획전</item>
+        <item>든든한 메인요리</item>
+        <item>뜨끈한 국물요리</item>
+        <item>정갈한 밑반찬</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,13 @@
     <string name="app_name">DeliverBanChan</string>
     <string name="app_bar_with_back_btn_title">Recently viewed products</string>
     <string name="app_bar_no_back_btn_title">ORDERING</string>
+
+    <string name="main_header_exhibition">한 번 주문하면
+            \n두 번 반하는 반찬들"</string>
+    <string name="main_header_main_dish">모두가 좋아하는
+            \n든든한 메인 요리"</string>
+    <string name="main_header_soup_dish">정성이 담긴
+            \n뜨끈뜨끈 국물 요리"</string>
+    <string name="main_header_side_dish">식탁을 풍성하게 하는
+            \n정갈한 밑반찬"</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,6 +14,11 @@
         <!-- Customize your theme here. -->
     </style>
 
+    <style name="cardViewRadius">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">50%</item>
+    </style>
+
     <!-- Appearance NotoSansKR -->
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack10_Medium.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -19,82 +19,101 @@
         <item name="cornerSize">50%</item>
     </style>
 
+    <style name="tab_text" parent="@android:style/TextAppearance.Widget.TabWidget">
+        <item name="android:fontFamily">@font/kopub_world_dotum_pro_bold_700</item>
+    </style>
+
     <!-- Appearance NotoSansKR -->
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack10_Medium.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_10sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_medium_500</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_12sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_normal_400</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleDefault12_Medium.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_default</item>
         <item name="android:textSize">@dimen/text_size_12sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_medium_500</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack14_Normal.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_14sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_normal_400</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack14_Medium.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_14sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_medium_500</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleDefault14_Normal.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_default</item>
         <item name="android:textSize">@dimen/text_size_14sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_normal_400</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_PrimaryAccent14_Medium.TextAppearance" parent="">
         <item name="android:textColor">@color/primary_accent</item>
         <item name="android:textSize">@dimen/text_size_14sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_medium_500</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack14_Bold.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_14sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_bold_700</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack18_Normal.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_18sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_normal_400</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleDefault18_Normal.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_default</item>
         <item name="android:textSize">@dimen/text_size_18sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_normal_400</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_PrimaryAccentk18_Bold.TextAppearance" parent="">
         <item name="android:textColor">@color/primary_accent</item>
         <item name="android:textSize">@dimen/text_size_18sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_bold_700</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack18_Medium.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_18sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_medium_500</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack18_Bold.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_18sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_bold_700</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleWhite18_Medium.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_white</item>
         <item name="android:textSize">@dimen/text_size_18sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_medium_500</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_32sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_normal_400</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack32_Medium.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_32sp</item>
@@ -107,6 +126,7 @@
         <item name="android:textSize">@dimen/text_size_14sp</item>
         <item name="android:fontFamily">@font/kopub_world_dotum_pro_bold_700</item>
     </style>
+
     <style name="Widget.TextView.KoPubWorldDotumPro_GreyScaleBlack16_Bold.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_16sp</item>
@@ -119,11 +139,13 @@
         <item name="android:textSize">@dimen/text_size_14sp</item>
         <item name="android:fontFamily">@font/outfit_bold_700</item>
     </style>
+
     <style name="Widget.TextView.Outfit_GreyScaleBlack20_Bold.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_20sp</item>
         <item name="android:fontFamily">@font/outfit_bold_700</item>
     </style>
+
     <style name="Widget.TextView.Outfit_GreyScaleBlack24_Bold.TextAppearance" parent="">
         <item name="android:textColor">@color/grey_scale_black</item>
         <item name="android:textSize">@dimen/text_size_24sp</item>
@@ -137,54 +159,63 @@
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleDefault12_Medium.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleDefault12_Medium.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack14_Normal.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleBlack14_Normal.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack14_Medium.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleBlack14_Medium.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleDefault14_Normal.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleDefault14_Normal.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_PrimaryAccent14_Medium.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_PrimaryAccent14_Medium.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack18_Medium.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleBlack18_Medium.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack18_Bold.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleBlack18_Bold.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleWhite18_Medium.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleWhite18_Medium.TextAppearance
@@ -198,30 +229,35 @@
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack14_Bold.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleBlack14_Bold.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleDefault18_Normal.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleDefault18_Normal.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_PrimaryAccentk18_Bold.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_PrimaryAccentk18_Bold.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.NotoSansKR_GreyScaleBlack32_Medium.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Medium.TextAppearance
@@ -237,12 +273,14 @@
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.Outfit_GreyScaleBlack20_Bold.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.Outfit_GreyScaleBlack20_Bold.TextAppearance
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.Outfit_GreyScaleBlack24_Bold.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.Outfit_GreyScaleBlack24_Bold.TextAppearance
@@ -257,6 +295,7 @@
         </item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
     <style name="Widget.TextView.KoPubWorldDotumPro_GreyScaleBlack16_Bold.Style" parent="">
         <item name="android:textAppearance">
             @style/Widget.TextView.KoPubWorldDotumPro_GreyScaleBlack16_Bold.TextAppearance


### PR DESCRIPTION
- CoordinatorLayout, CollapsingToolbarLayout 사용
- 헤더 텍스트 영역 외에 필터 부분 영역 잡으려고 임시로 배치해둔 부분있음