### PR TITLE
[CHORE] 든든한 메인 요리 linear 타입 어댑터 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <application
         android:name=".GlobalApplication"
         android:allowBackup="true"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/domain/usecase/CreateEmptyUiDishItemUseCase.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/domain/usecase/CreateEmptyUiDishItemUseCase.kt
@@ -7,6 +7,6 @@ import javax.inject.Singleton
 @Singleton
 class CreateEmptyUiDishItemUseCase @Inject constructor() {
     suspend operator fun invoke() = UiDishItem(
-        "", "", false, "", "", 0, 0, 0, 0
+        "", "", false, "", "", 0, 0, "0%", 0
     )
 }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/maindish/adapter/MainDishLinearAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/maindish/adapter/MainDishLinearAdapter.kt
@@ -2,6 +2,7 @@ package com.woowahan.android10.deliverbanchan.presentation.maindish.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -15,8 +16,9 @@ class MainDishLinearAdapter(
 
     inner class MainDishLinearViewHolder(val binding: ItemMaindishLinearBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(uiDishItem: UiDishItem, cartIconClick: (uiDishItem: UiDishItem) -> Unit) {
+        fun bind(uiDishItem: UiDishItem, cartIconClick: (uiDishItem: UiDishItem) -> Unit, isLast: Boolean) {
             binding.uiDishItem = uiDishItem
+            binding.maindishViewFooter.isVisible = isLast
             binding.maindishIbCart.setOnClickListener {
                 cartIconClick.invoke(uiDishItem)
             }
@@ -34,7 +36,7 @@ class MainDishLinearAdapter(
     }
 
     override fun onBindViewHolder(holder: MainDishLinearViewHolder, position: Int) {
-        holder.bind(getItem(position), cartIconClick)
+        holder.bind(getItem(position), cartIconClick, position == currentList.size - 1)
     }
 
     companion object UiDishItemDiffUtil : DiffUtil.ItemCallback<UiDishItem>() {

--- a/app/src/main/res/layout/fragment_maindish.xml
+++ b/app/src/main/res/layout/fragment_maindish.xml
@@ -33,13 +33,13 @@
                         app:layout_constraintTop_toTopOf="parent">
 
                         <TextView
+                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="@dimen/base_space_16dp"
                             android:layout_marginTop="53dp"
                             android:layout_marginBottom="53dp"
                             android:text="@string/main_header_main_dish"
-                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
@@ -53,29 +53,31 @@
                         android:layout_marginTop="24dp"
                         app:layout_constraintTop_toBottomOf="@id/maindish_cl_header_text">
 
-                       <RadioGroup
-                           android:id="@+id/maindish_rg"
-                           android:layout_width="wrap_content"
-                           android:layout_height="wrap_content"
-                           app:layout_constraintStart_toStartOf="parent"
-                           app:layout_constraintTop_toTopOf="parent"
-                           app:layout_constraintBottom_toBottomOf="parent"
-                           android:layout_marginStart="@dimen/base_space_16dp"
-                           android:orientation="horizontal">
-                           <androidx.appcompat.widget.AppCompatRadioButton
-                               android:id="@+id/maindish_rb_grid"
-                               android:layout_width="24dp"
-                               android:layout_height="24dp"
-                               android:button="@null"
-                               android:background="@drawable/selector_maindish_grid"
-                               android:checked="true"/>
-                           <androidx.appcompat.widget.AppCompatRadioButton
-                               android:id="@+id/maindish_rb_linear"
-                               android:layout_width="24dp"
-                               android:layout_height="24dp"
-                               android:button="@null"
-                               android:background="@drawable/selector_maindish_linear"/>
-                       </RadioGroup>
+                        <RadioGroup
+                            android:id="@+id/maindish_rg"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/base_space_16dp"
+                            android:orientation="horizontal"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent">
+
+                            <androidx.appcompat.widget.AppCompatRadioButton
+                                android:id="@+id/maindish_rb_grid"
+                                android:layout_width="24dp"
+                                android:layout_height="24dp"
+                                android:background="@drawable/selector_maindish_grid"
+                                android:button="@null"
+                                android:checked="true" />
+
+                            <androidx.appcompat.widget.AppCompatRadioButton
+                                android:id="@+id/maindish_rb_linear"
+                                android:layout_width="24dp"
+                                android:layout_height="24dp"
+                                android:background="@drawable/selector_maindish_linear"
+                                android:button="@null" />
+                        </RadioGroup>
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -89,7 +91,6 @@
             android:id="@+id/maindish_rv"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="40dp"
             app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_maindish_linear.xml
+++ b/app/src/main/res/layout/item_maindish_linear.xml
@@ -20,7 +20,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/base_space_16dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/maindish_view_footer"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
@@ -105,10 +105,17 @@
             android:layout_marginStart="16dp"
             android:gravity="center_vertical"
             android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/maindish_view_footer"
             app:layout_constraintStart_toEndOf="@id/maindish_fl"
             app:layout_constraintTop_toBottomOf="@id/maindish_tv_sPrice"
             tools:text="12,640원" />
+
+        <View
+            android:id="@+id/maindish_view_footer"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- 리사이클러뷰 하단 여백 확보 위함
- 마지막 아이템은 아이템뷰에 만든 empty view의 visibility를 visible 로 설정
- 그 외 아이템은 gone 처리