### PR TITLE
[FIX] 화면 회전 후 landscape 모드에서 cart Bottom Sheet 완전히 보이지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/bottomsheet/CartBottomSheetFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/bottomsheet/CartBottomSheetFragment.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.FragmentCartBottomSheetBinding
@@ -26,6 +27,12 @@ class CartBottomSheetFragment : BottomSheetDialogFragment() {
         super.onCreate(savedInstanceState)
 
         setStyle(STYLE_NORMAL, R.style.AppBottomSheetDialogTheme)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val behavior = BottomSheetBehavior.from(requireView().parent as View)
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
 
     override fun onCreateView(


### PR DESCRIPTION
- BottomSheetFragment 의 onStart에서 behavior state 를  BottomSheetBehavior.STATE_EXPANDED 로 설정하는 방법으로 수정