### PR TITLE
[CHORE] 메인 요리 화면 수정

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
@@ -23,7 +23,7 @@ class MainDishFragment :
 
     private val mainDishViewModel: MainDishViewModel by viewModels()
     private lateinit var mainDishLinearAdapter: MainDishLinearAdapter
-    private lateinit var mainDishGridAdapter: SoupAdapter
+    private lateinit var mainDishGridAdapter: MainDishGridAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -62,10 +62,9 @@ class MainDishFragment :
 
     private fun setRecyclerView() {
 
-        mainDishGridAdapter = SoupAdapter()
+        mainDishGridAdapter = MainDishGridAdapter()
 
         mainDishLinearAdapter = MainDishLinearAdapter {
-            // bottom sheet 에 uiDishItem 전달하기
             Log.e("TAG", "cart icon clicked")
             val cartBottomSheetFragment = CartBottomSheetFragment()
             val bundle = Bundle()

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishGridAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishGridAdapter.kt
@@ -1,0 +1,49 @@
+package com.woowahan.android10.deliverbanchan.presentation.main.maindish
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.woowahan.android10.deliverbanchan.databinding.ItemMaindishGridBinding
+import com.woowahan.android10.deliverbanchan.databinding.ItemSoupBinding
+import com.woowahan.android10.deliverbanchan.domain.model.UiDishItem
+
+
+class MainDishGridAdapter : ListAdapter<UiDishItem, MainDishGridAdapter.ViewHolder>(diffUtil) {
+
+    companion object {
+        const val TAG = "MainDishGridAdapter"
+        val diffUtil = object : DiffUtil.ItemCallback<UiDishItem>() {
+            override fun areItemsTheSame(oldItem: UiDishItem, newItem: UiDishItem): Boolean {
+                return oldItem.hash == newItem.hash
+            }
+
+            override fun areContentsTheSame(oldItem: UiDishItem, newItem: UiDishItem): Boolean {
+                return newItem == oldItem
+            }
+        }
+    }
+
+    inner class ViewHolder(private val binding: ItemMaindishGridBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(uiDishItem: UiDishItem, position: Int) {
+            binding.item = uiDishItem
+            binding.viewLeft.isVisible = (position % 2 == 0)
+            binding.viewRight.isVisible = (position % 2 != 0)
+            binding.executePendingBindings()
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding =
+            ItemMaindishGridBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position), position)
+    }
+}

--- a/app/src/main/res/layout/fragment_maindish.xml
+++ b/app/src/main/res/layout/fragment_maindish.xml
@@ -23,7 +23,7 @@
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="16dp">
+                    android:layout_marginBottom="24dp">
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/maindish_cl_header_text"

--- a/app/src/main/res/layout/item_maindish_grid.xml
+++ b/app/src/main/res/layout/item_maindish_grid.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="item"
+            type="com.woowahan.android10.deliverbanchan.domain.model.UiDishItem" />
+
+        <import type="android.view.View" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/soup_root"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="4dp"
+        android:layout_marginBottom="@dimen/cart_btn_width_32dp">
+
+        <View
+            android:id="@+id/view_left"
+            android:layout_width="12dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"/>
+
+        <View
+            android:id="@+id/view_right"
+            android:layout_width="12dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+
+        <FrameLayout
+            android:id="@+id/maindish_fl"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toStartOf="@id/view_right"
+            app:layout_constraintStart_toEndOf="@id/view_left"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/maindish_iv_image"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:setStringUrlImage="@{item.image}" />
+
+            <ImageButton
+                android:id="@+id/maindish_imb_cart"
+                android:layout_width="@dimen/cart_btn_width_32dp"
+                android:layout_height="@dimen/cart_btn_width_32dp"
+                android:layout_gravity="bottom|end"
+                android:layout_marginEnd="@dimen/rv_space_8dp"
+                android:layout_marginBottom="@dimen/rv_space_8dp"
+                android:background="@drawable/btn_cart_32dp"
+                android:elevation="2dp" />
+        </FrameLayout>
+
+        <TextView
+            android:id="@+id/maindish_tv_title"
+            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack14_Medium.Style"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/text_size_24sp"
+            android:layout_marginTop="@dimen/rv_space_8dp"
+            android:ellipsize="end"
+            android:gravity="center_vertical"
+            android:maxLines="1"
+            android:text="@{item.title}"
+            app:layout_constraintEnd_toEndOf="@id/maindish_fl"
+            app:layout_constraintStart_toStartOf="@id/maindish_fl"
+            app:layout_constraintTop_toBottomOf="@id/maindish_fl" />
+
+        <TextView
+            android:id="@+id/maindish_tv_description"
+            style="@style/Widget.TextView.NotoSansKR_GreyScaleDefault12_Medium.Style"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/text_size_24sp"
+            android:ellipsize="end"
+            android:gravity="center_vertical"
+            android:maxLines="1"
+            android:text="@{item.description}"
+            app:layout_constraintEnd_toEndOf="@+id/maindish_tv_title"
+            app:layout_constraintStart_toStartOf="@+id/maindish_tv_title"
+            app:layout_constraintTop_toBottomOf="@+id/maindish_tv_title" />
+
+        <TextView
+            android:id="@+id/maindish_tv_percentage"
+            style="@style/Widget.TextView.NotoSansKR_PrimaryAccent14_Medium.Style"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/text_size_24sp"
+            android:gravity="center_vertical"
+            android:paddingEnd="@dimen/rv_space_4dp"
+            android:text="@{String.valueOf(item.salePercentage)+`%`}"
+            android:visibility="@{item.NPrice==0?View.GONE:View.VISIBLE}"
+            app:layout_constraintStart_toStartOf="@+id/maindish_tv_description"
+            app:layout_constraintTop_toBottomOf="@+id/maindish_tv_description" />
+
+        <TextView
+            android:id="@+id/maindish_tv_sprice"
+            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack14_Medium.Style"
+            isNPrice="@{false}"
+            price="@{item.SPrice}"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/text_size_24sp"
+            android:gravity="center_vertical"
+            app:layout_constraintBottom_toTopOf="@+id/maindish_tv_nprice"
+            app:layout_constraintStart_toEndOf="@+id/maindish_tv_percentage"
+            app:layout_constraintTop_toBottomOf="@+id/maindish_tv_description" />
+
+        <TextView
+            android:id="@+id/maindish_tv_nprice"
+            style="@style/Widget.TextView.NotoSansKR_GreyScaleDefault12_Normal.Style"
+            isNPrice="@{true}"
+            price="@{item.NPrice}"
+            android:layout_width="0dp"
+            android:layout_height="@dimen/text_size_24sp"
+            android:gravity="center_vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/maindish_tv_percentage"
+            app:layout_constraintTop_toBottomOf="@+id/maindish_tv_sprice" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_maindish_linear.xml
+++ b/app/src/main/res/layout/item_maindish_linear.xml
@@ -14,7 +14,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="8dp">
+        android:paddingBottom="8dp">
 
         <FrameLayout
             android:id="@+id/maindish_fl"
@@ -114,7 +114,7 @@
         <View
             android:id="@+id/maindish_view_footer"
             android:layout_width="match_parent"
-            android:layout_height="40dp"
+            android:layout_height="32dp"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent" />
 


### PR DESCRIPTION
- 필터 & 리사이클러뷰 간격 수정
- 그리드, 리니어 각각 아이템뷰 수정
- 그리드 : 기본적으로 margin 좌우 4dp /  1열에 위치하는 아이템은 왼쪽, 2열에 위치하는 아이템은 오른쪽에 공간 추가적으로 생기게 구현