### PR TITLE
[FIX] 기획전 화면 수직 스크롤 수정

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_2_API_31.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_4_API_32.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-08-14T13:52:25.879313Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-08-16T10:50:20.878303Z" />
   </component>
 </project>

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/adapter/DetailThumbImageAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/adapter/DetailThumbImageAdapter.kt
@@ -2,9 +2,12 @@ package com.woowahan.android10.deliverbanchan.presentation.detail.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.tabs.TabLayoutMediator
+import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.ItemDetailThumbImageRvBinding
 
 class DetailThumbImageAdapter :
@@ -19,7 +22,17 @@ class DetailThumbImageAdapter :
             binding.detailVpThumb.apply {
                 adapter = vpAdapter
             }
+
+            TabLayoutMediator(binding.detailTl, binding.detailVpThumb) { tab, position ->
+                tab.text = "  "
+            }.attach()
+
             vpAdapter.submitList(imgUrlList.toList())
+
+            imgUrlList.forEachIndexed{index, url ->
+                val textView = LayoutInflater.from(binding.root.context).inflate(R.layout.tab_indicator, null) as TextView
+                binding.detailTl.getTabAt(index)?.customView = textView
+            }
         }
     }
 

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/adapter/DetailThumbViewPagerAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/adapter/DetailThumbViewPagerAdapter.kt
@@ -34,6 +34,8 @@ class DetailThumbViewPagerAdapter :
         holder.bind(getItem(position))
     }
 
+    override fun getItemCount() = currentList.size
+
     companion object DetailThumbViewPagerDiffUtil : DiffUtil.ItemCallback<String>() {
         override fun areItemsTheSame(oldItem: String, newItem: String) =
             oldItem == newItem

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.FragmentExhibitionBinding
@@ -27,6 +28,8 @@ class ExhibitionFragment :
     BaseFragment<FragmentExhibitionBinding>(R.layout.fragment_exhibition, "ExhibitionFragment") {
 
     private val exhibitionViewModel: ExhibitionViewModel by viewModels()
+    private lateinit var concatAdapter: ConcatAdapter
+    private lateinit var exhibitionHeaderAdapter: ExhibitionHeaderAdapter
     private lateinit var exhibitionAdapter: ExhibitionAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -36,11 +39,18 @@ class ExhibitionFragment :
     }
 
     private fun initView() {
+        setExhibitionHeaderAdpater()
+        setExhibitionContentAdapter()
         setRecyclerView()
         initObserver()
     }
 
-    private fun setRecyclerView() {
+    private fun setExhibitionHeaderAdpater() {
+        exhibitionHeaderAdapter = ExhibitionHeaderAdapter()
+        exhibitionHeaderAdapter.submitList(listOf("header").toList())
+    }
+
+    private fun setExhibitionContentAdapter() {
         exhibitionAdapter = ExhibitionAdapter ({
             val cartBottomSheetFragment = CartBottomSheetFragment()
 
@@ -77,8 +87,14 @@ class ExhibitionFragment :
             intent.putExtra("UiDishItem", it)
             startActivity(intent)
         })
+    }
+
+    private fun setRecyclerView() {
+        concatAdapter =
+            ConcatAdapter(exhibitionHeaderAdapter, exhibitionAdapter)
+
         binding.exhibitionRv.apply {
-            adapter = exhibitionAdapter
+            adapter = concatAdapter
             layoutManager = LinearLayoutManager(requireContext())
         }
     }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionHeaderAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionHeaderAdapter.kt
@@ -1,0 +1,39 @@
+package com.woowahan.android10.deliverbanchan.presentation.main.exhibition
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.woowahan.android10.deliverbanchan.databinding.ItemExhibitionHeaderBinding
+
+class ExhibitionHeaderAdapter :
+    ListAdapter<String, ExhibitionHeaderAdapter.ExhibitionHeaderViewHolder>(ExhibitionHeaderDiffUtil) {
+
+    inner class ExhibitionHeaderViewHolder(private val binding: ItemExhibitionHeaderBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(str: String) {}
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ExhibitionHeaderViewHolder {
+        val binding =
+            ItemExhibitionHeaderBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        return ExhibitionHeaderViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ExhibitionHeaderViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object ExhibitionHeaderDiffUtil : DiffUtil.ItemCallback<String>() {
+        override fun areItemsTheSame(oldItem: String, newItem: String) =
+            oldItem == newItem
+
+        override fun areContentsTheSame(oldItem: String, newItem: String) =
+            oldItem == newItem
+    }
+}

--- a/app/src/main/res/drawable/tab_indicator_background_selector.xml
+++ b/app/src/main/res/drawable/tab_indicator_background_selector.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true"
+        android:drawable="@drawable/tab_indicator_selected_background" />
+    <item android:state_selected="false"
+        android:drawable="@drawable/tab_indicator_unselected_background" />
+</selector>

--- a/app/src/main/res/drawable/tab_indicator_selected_background.xml
+++ b/app/src/main/res/drawable/tab_indicator_selected_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="7dp"
+        android:top="7dp"
+        android:left="10dp">
+        <shape android:shape="rectangle">
+            <corners android:radius="28dp" />
+            <solid android:color="@color/primary_main" />
+        </shape>
+    </item>
+</layer-list>
+

--- a/app/src/main/res/drawable/tab_indicator_unselected_background.xml
+++ b/app/src/main/res/drawable/tab_indicator_unselected_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:bottom="7dp"
+        android:top="7dp"
+        android:left="10dp">
+        <shape android:shape="rectangle">
+            <corners android:radius="28dp" />
+            <solid android:color="#4D000000" />
+        </shape>
+    </item>
+</layer-list>
+

--- a/app/src/main/res/layout/fragment_exhibition.xml
+++ b/app/src/main/res/layout/fragment_exhibition.xml
@@ -6,72 +6,9 @@
 
     </data>
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-
-        <com.google.android.material.appbar.AppBarLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@color/white">
-
-            <com.google.android.material.appbar.CollapsingToolbarLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed">
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="24dp"
-                    android:background="@color/primary_surface">
-
-                    <com.google.android.material.card.MaterialCardView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="@dimen/base_space_16dp"
-                        android:layout_marginTop="36dp"
-                        android:backgroundTint="@color/grey_scale_surface"
-                        app:cardElevation="0dp"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:shapeAppearanceOverlay="@style/cardViewRadius"
-                        app:strokeColor="@color/grey_scale_black"
-                        app:strokeWidth="1dp">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:fontFamily="@font/noto_sans_kr_medium_500"
-                            android:gravity="center"
-                            android:includeFontPadding="false"
-                            android:paddingHorizontal="14dp"
-                            android:paddingVertical="5dp"
-                            android:text="기획전"
-                            android:textColor="@color/grey_scale_black"
-                            android:textSize="@dimen/text_size_10sp" />
-
-                    </com.google.android.material.card.MaterialCardView>
-
-                    <TextView
-                        style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="@dimen/base_space_16dp"
-                        android:layout_marginTop="70dp"
-                        android:layout_marginBottom="36dp"
-                        android:includeFontPadding="false"
-                        android:text="@string/main_header_exhibition"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-            </com.google.android.material.appbar.CollapsingToolbarLayout>
-
-        </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/exhibition_rv"
@@ -85,7 +22,11 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:indeterminateBehavior="repeat"
-            android:indeterminateTint="@color/progress_indicator" />
+            android:indeterminateTint="@color/progress_indicator"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_detail_thumb_image_rv.xml
+++ b/app/src/main/res/layout/item_detail_thumb_image_rv.xml
@@ -17,5 +17,20 @@
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/detail_tl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:tabIndicatorHeight="0dp"
+            app:tabMode="scrollable"
+            android:background="#00000000"
+            app:tabRippleColor="@null"
+            app:tabPaddingStart="5dp"
+            app:tabPaddingEnd="3dp"
+            app:tabMinWidth="60dp"
+            />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_exhibition_header.xml
+++ b/app/src/main/res/layout/item_exhibition_header.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:background="@color/primary_surface">
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/base_space_16dp"
+            android:layout_marginTop="36dp"
+            android:backgroundTint="@color/grey_scale_surface"
+            app:cardElevation="0dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearanceOverlay="@style/cardViewRadius"
+            app:strokeColor="@color/grey_scale_black"
+            app:strokeWidth="1dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:fontFamily="@font/noto_sans_kr_medium_500"
+                android:gravity="center"
+                android:includeFontPadding="false"
+                android:paddingHorizontal="14dp"
+                android:paddingVertical="5dp"
+                android:text="기획전"
+                android:textColor="@color/grey_scale_black"
+                android:textSize="@dimen/text_size_10sp" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <TextView
+            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/base_space_16dp"
+            android:layout_marginTop="70dp"
+            android:layout_marginBottom="36dp"
+            android:includeFontPadding="false"
+            android:text="@string/main_header_exhibition"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/tab_indicator.xml
+++ b/app/src/main/res/layout/tab_indicator.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@android:id/text1"
+    android:layout_width="20dp"
+    android:layout_height="1dp"
+    android:background="@drawable/tab_indicator_background_selector"
+    android:gravity="center"
+    tools:text="Title" />
+
+


### PR DESCRIPTION
- 기존의 CoordinatorLayout + RecyclerView로 구현 시 리사이클러뷰 영역만 수직 스크롤이 되는 문제 발생 (전체가 한번에 올라가지 않음)

---

< 해결방법 >
- 화면전체를 리사이클러뷰로 감싸고 ConcatAdapter 사용
- 헤더 영역(상단 문구) + 바디 영역(기획전 리스트) 각각 어댑터를 만들어서 사용