### PR TITLE
[FIX] 기획전 수평 스크롤 수정

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/common/NestedScrollableHost.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/common/NestedScrollableHost.kt
@@ -1,0 +1,101 @@
+package com.woowahan.android10.deliverbanchan.presentation.main.common
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Log
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewConfiguration
+import android.widget.FrameLayout
+import androidx.viewpager2.widget.ViewPager2
+import androidx.viewpager2.widget.ViewPager2.ORIENTATION_HORIZONTAL
+import kotlin.math.absoluteValue
+import kotlin.math.sign
+
+class NestedScrollableHost : FrameLayout {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    private var touchSlop = 0
+    private var initialX = 0f
+    private var initialY = 0f
+    private val parentViewPager: ViewPager2?
+        get() {
+            var v: View? = parent as? View
+            while (v != null && v !is ViewPager2) {
+                v = v.parent as? View
+            }
+            return v as? ViewPager2
+        }
+
+    private val child: View? get() = if (childCount > 0) getChildAt(0) else null
+
+    init {
+        touchSlop = ViewConfiguration.get(context).scaledTouchSlop
+        // Log.e("NestedScrollableHost", " init touchSlop : $touchSlop")
+    }
+
+    private fun canChildScroll(orientation: Int, delta: Float): Boolean {
+        val direction = -delta.sign.toInt()
+        Log.e("NestedScrollableHost", "canChildScroll direction : $direction")
+        return when (orientation) {
+            0 -> child?.canScrollHorizontally(direction) ?: false
+            1 -> child?.canScrollVertically(direction) ?: false
+            else -> throw IllegalArgumentException()
+        }
+    }
+
+    override fun onInterceptTouchEvent(e: MotionEvent): Boolean {
+        handleInterceptTouchEvent(e)
+        return super.onInterceptTouchEvent(e)
+    }
+
+    private fun handleInterceptTouchEvent(e: MotionEvent) {
+        val orientation = parentViewPager?.orientation ?: return
+        Log.e("NestedScrollableHost", "handleInterceptTouchEvent orientation : $orientation")
+        // Early return if child can't scroll in same direction as parent
+        if (!canChildScroll(orientation, -1f) && !canChildScroll(orientation, 1f)) {
+            Log.e("NestedScrollableHost", "return")
+            return
+        }
+
+        if (e.action == MotionEvent.ACTION_DOWN) {
+            initialX = e.x
+            initialY = e.y
+            parent.requestDisallowInterceptTouchEvent(true)
+            // Log.e("NestedScrollableHost", "handleInterceptTouchEvent initialX : $initialX , initialY : $initialY")
+        } else if (e.action == MotionEvent.ACTION_MOVE) {
+            val dx = e.x - initialX
+            val dy = e.y - initialY
+            val isVpHorizontal = orientation == ORIENTATION_HORIZONTAL
+
+            // assuming ViewPager2 touch-slop is 2x touch-slop of child
+
+            val scaledDx = dx.absoluteValue * if (isVpHorizontal) .5f else 1f
+            val scaledDy = dy.absoluteValue * if (isVpHorizontal) 1f else .5f
+
+//            Log.e("NestedScrollableHost", "handleInterceptTouchEvent scaledDx : $scaledDx , scaledDy : $scaledDy")
+//            Log.e("NestedScrollableHost", "handleInterceptTouchEvent dx : $dx , dy : $dy")
+//            Log.e("NestedScrollableHost", "handleInterceptTouchEvent ey : ${e.y} , ex : ${e.x}")
+
+
+            if (scaledDx > touchSlop || scaledDy > touchSlop) {
+                if (isVpHorizontal == (scaledDy > scaledDx)) {
+                    // Gesture is perpendicular, allow all parents to intercept
+                    parent.requestDisallowInterceptTouchEvent(false)
+                } else {
+                    // Gesture is parallel, query child if movement in that direction is possible
+                    if (canChildScroll(orientation, if (isVpHorizontal) dx else dy)) {
+                        // Child can scroll, disallow all parents to intercept
+                        Log.e("NestedScrollableHost", "can scroll")
+                        parent.requestDisallowInterceptTouchEvent(true)
+                    } else {
+                        // Child cannot scroll, allow all parents to intercept
+                        Log.e("NestedScrollableHost", "cannot scroll")
+                        parent.requestDisallowInterceptTouchEvent(false)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/common/NestedScrollableHost.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/common/NestedScrollableHost.kt
@@ -32,7 +32,6 @@ class NestedScrollableHost : FrameLayout {
 
     init {
         touchSlop = ViewConfiguration.get(context).scaledTouchSlop
-        // Log.e("NestedScrollableHost", " init touchSlop : $touchSlop")
     }
 
     private fun canChildScroll(orientation: Int, delta: Float): Boolean {
@@ -52,8 +51,8 @@ class NestedScrollableHost : FrameLayout {
 
     private fun handleInterceptTouchEvent(e: MotionEvent) {
         val orientation = parentViewPager?.orientation ?: return
-        Log.e("NestedScrollableHost", "handleInterceptTouchEvent orientation : $orientation")
-        // Early return if child can't scroll in same direction as parent
+
+        // 자식뷰가 어느 방향으로도 스크롤 할 수 없는 경우에는 바로 return
         if (!canChildScroll(orientation, -1f) && !canChildScroll(orientation, 1f)) {
             Log.e("NestedScrollableHost", "return")
             return
@@ -63,34 +62,27 @@ class NestedScrollableHost : FrameLayout {
             initialX = e.x
             initialY = e.y
             parent.requestDisallowInterceptTouchEvent(true)
-            // Log.e("NestedScrollableHost", "handleInterceptTouchEvent initialX : $initialX , initialY : $initialY")
         } else if (e.action == MotionEvent.ACTION_MOVE) {
             val dx = e.x - initialX
             val dy = e.y - initialY
             val isVpHorizontal = orientation == ORIENTATION_HORIZONTAL
 
-            // assuming ViewPager2 touch-slop is 2x touch-slop of child
-
+            // ViewPager2의 touch-slop이 자식 뷰의 touch-slop 보다 2배 크다고 가정하는 것을 하기 위함
             val scaledDx = dx.absoluteValue * if (isVpHorizontal) .5f else 1f
             val scaledDy = dy.absoluteValue * if (isVpHorizontal) 1f else .5f
 
-//            Log.e("NestedScrollableHost", "handleInterceptTouchEvent scaledDx : $scaledDx , scaledDy : $scaledDy")
-//            Log.e("NestedScrollableHost", "handleInterceptTouchEvent dx : $dx , dy : $dy")
-//            Log.e("NestedScrollableHost", "handleInterceptTouchEvent ey : ${e.y} , ex : ${e.x}")
-
-
             if (scaledDx > touchSlop || scaledDy > touchSlop) {
                 if (isVpHorizontal == (scaledDy > scaledDx)) {
-                    // Gesture is perpendicular, allow all parents to intercept
+                    // 수직 스크롤인 경우에는 부모뷰가 터치 이벤트 가져가도록 설정
                     parent.requestDisallowInterceptTouchEvent(false)
                 } else {
-                    // Gesture is parallel, query child if movement in that direction is possible
+                    // 수평 스크롤인 경우
                     if (canChildScroll(orientation, if (isVpHorizontal) dx else dy)) {
-                        // Child can scroll, disallow all parents to intercept
+                        // 자식뷰가 현재 방향으로 수평 스크롤 가능 시 이벤트 가져온다
                         Log.e("NestedScrollableHost", "can scroll")
                         parent.requestDisallowInterceptTouchEvent(true)
                     } else {
-                        // Child cannot scroll, allow all parents to intercept
+                        // 반대로 자식뷰에서 현재 방향(우측 or 좌측)으로 스크롤 더 이상 안될 시 부모뷰로 이벤트 넘긴다
                         Log.e("NestedScrollableHost", "cannot scroll")
                         parent.requestDisallowInterceptTouchEvent(false)
                     }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionAdapter.kt
@@ -1,6 +1,7 @@
 package com.woowahan.android10.deliverbanchan.presentation.main.exhibition
 
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.ViewGroup
 import androidx.recyclerview.widget.*
 import com.woowahan.android10.deliverbanchan.databinding.ItemExhibitionBinding
@@ -48,6 +49,7 @@ class ExhibitionAdapter(
                 }
             }
             exhibitonHorizontalAdpater.submitList(uiExhibitionItem.uiDishItems.toList())
+
             binding.executePendingBindings()
         }
     }

--- a/app/src/main/res/layout/item_exhibition.xml
+++ b/app/src/main/res/layout/item_exhibition.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="uiExhibitionItem"
             type="com.woowahan.android10.deliverbanchan.domain.model.UiExhibitionItem" />
@@ -20,19 +21,24 @@
             android:layout_height="24dp"
             android:layout_marginStart="@dimen/base_space_16dp"
             android:gravity="center_vertical"
+            android:text="@{uiExhibitionItem.categoryName}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="풍성한 고기반찬"
-            android:text="@{uiExhibitionItem.categoryName}"/>
+            tools:text="풍성한 고기반찬" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/exhibition_rv_horizontal"
+        <com.woowahan.android10.deliverbanchan.presentation.main.common.NestedScrollableHost
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/base_space_16dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/exhibition_tv_category_name" />
+            app:layout_constraintTop_toBottomOf="@id/exhibition_tv_category_name">
 
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/exhibition_rv_horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </com.woowahan.android10.deliverbanchan.presentation.main.common.NestedScrollableHost>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- 기획전 화면의 Horizontal RecyclerView 수평 스크롤 동작 시 전체 ViewPager2 가 스와이프 되는 문제
- Horizontal RecyclerView 영역 수평 스크롤 시 어느 방향으로도 스크롤이 가능한 상태라면 터치 이벤트를 부모 뷰로 넘기지 않고 가져온다
- 수평 스크롤 시 좌측 or 우측 끝에 도달해 더 이상 스크롤 할 수 없는 상태에서는 부모뷰가 이벤트를 가져간다 -> 이 상태에서 스크롤 시 뷰페이저 전체가 스와이프 되어 다음 탭으로 넘어갈 수 있다