### PR TITLE
[FEAT] 상세 화면 주문하기 버튼 누를 시 동작, 메인 탭별 다이얼로그 동작

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailActivity.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailActivity.kt
@@ -1,5 +1,6 @@
 package com.woowahan.android10.deliverbanchan.presentation.detail
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.viewModels
@@ -12,10 +13,12 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.ActivityDetailBinding
 import com.woowahan.android10.deliverbanchan.presentation.base.BaseActivity
+import com.woowahan.android10.deliverbanchan.presentation.cart.CartActivity
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.showToast
 import com.woowahan.android10.deliverbanchan.presentation.detail.adapter.DetailContentAdapter
 import com.woowahan.android10.deliverbanchan.presentation.detail.adapter.DetailSectionImageAdapter
 import com.woowahan.android10.deliverbanchan.presentation.detail.adapter.DetailThumbImageAdapter
+import com.woowahan.android10.deliverbanchan.presentation.dialogs.dialog.CartDialogFragment
 import com.woowahan.android10.deliverbanchan.presentation.state.DetailUiState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -36,6 +39,7 @@ class DetailActivity :
         initView()
         observeApiState()
         observeDetailData()
+        observeInsertSuccess()
     }
 
     private fun initView() {
@@ -117,6 +121,27 @@ class DetailActivity :
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 detailViewModel.sectionList.collect {
                     detailSectionImageAdapter.submitList(it.toList())
+                }
+            }
+        }
+    }
+
+    private fun observeInsertSuccess() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                detailViewModel.insertSuccessEvent.collect {
+                    if(it) {
+                        val cartDialog = CartDialogFragment()
+                        cartDialog.setTextClickListener(object : CartDialogFragment.TextClickListener {
+                            override fun moveToCartTextClicked(hash: String, title: String) {
+                                Log.e("DetailActivity", "move to cart")
+                                startActivity(Intent(this@DetailActivity, CartActivity::class.java))
+                            }
+                        })
+                        cartDialog.show(supportFragmentManager, "CartDialog")
+                    } else {
+                        showToast("장바구니 담기에 실패했습니다.")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailActivity.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailActivity.kt
@@ -46,15 +46,14 @@ class DetailActivity :
         detailThumbImageAdapter = DetailThumbImageAdapter()
         detailContentAdapter = DetailContentAdapter({
             // minus click
-            Log.e("DetailActivity", "minus click")
             detailViewModel.minusItemCount()
         }, {
             // plus click
-            Log.e("DetailActivity", "plus click")
             detailViewModel.plusItemCount()
         }, {
             // button click
             Log.e("DetailActivity", "button click")
+            detailViewModel.orderDetailItem()
         })
         detailSectionImageAdapter = DetailSectionImageAdapter()
 

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailViewModel.kt
@@ -23,6 +23,7 @@ class DetailViewModel @Inject constructor(
     private val createUiDetailInfoUseCase: CreateUiDetailInfoUseCase,
     private val getDetailDishUseCase: GetDetailDishUseCase,
     private val insertRecentlyUseCase: InsertRecentlyUseCase,
+    private val insertCartInfoUseCase: InsertCartInfoUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -42,6 +43,9 @@ class DetailViewModel @Inject constructor(
 
     private val _itemCount = MutableStateFlow<Int>(1)
     val itemCount: StateFlow<Int> = _itemCount
+
+    private val _insertSuccessEvent = MutableSharedFlow<Boolean>()
+    val insertSuccessEvent = _insertSuccessEvent.asSharedFlow()
 
     init {
         getDetailDishInfo()
@@ -87,6 +91,28 @@ class DetailViewModel @Inject constructor(
                     }
                     is BaseResult.Error -> _detailState.value =
                         DetailUiState.Error(result.errorCode)
+                }
+            }
+        }
+    }
+
+    fun orderDetailItem() {
+        // 현재 상품이 장바구니에 있는지를 알아야 한다
+        viewModelScope.launch {
+            currentUiDishItem?.let {
+                runCatching {
+                    var itemCount = 0
+                    if (it.isInserted) {
+                        // 이미 장바구니에 있는 경우
+
+                    } else {
+                        // 새로 장바구니에 들어가는 경우
+
+                    }
+                }.onSuccess {
+                    _insertSuccessEvent.emit(true)
+                }.onFailure {
+                    _insertSuccessEvent.emit(false)
                 }
             }
         }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.FragmentExhibitionBinding
 import com.woowahan.android10.deliverbanchan.presentation.base.BaseFragment
+import com.woowahan.android10.deliverbanchan.presentation.cart.CartActivity
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.showToast
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.toGone
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.toVisible
@@ -63,8 +64,7 @@ class ExhibitionFragment :
                     cartDialog.setTextClickListener(object : CartDialogFragment.TextClickListener {
                         override fun moveToCartTextClicked(hash: String, title: String) {
                             Log.e("ExhibitionFragment", "move to cart, hash : ${hash}, title : ${title}")
-
-                            // CartActivity 이동 하면서 title, hash 전달 예정
+                            startActivity(Intent(requireActivity(), CartActivity::class.java))
                         }
                     })
 

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.FragmentMaindishBinding
 import com.woowahan.android10.deliverbanchan.presentation.base.BaseFragment
+import com.woowahan.android10.deliverbanchan.presentation.cart.CartActivity
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.showToast
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.toGone
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.toVisible
@@ -90,8 +91,7 @@ class MainDishFragment :
                                     "MainDishFragment",
                                     "move to cart, hash : ${hash}, title : ${title}"
                                 )
-
-                                // CartActivity 이동 하면서 title, hash 전달 예정
+                                startActivity(Intent(requireActivity(), CartActivity::class.java))
                             }
                         })
 

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/sidedish/SideDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/sidedish/SideDishFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.FragmentSidedishBinding
 import com.woowahan.android10.deliverbanchan.presentation.base.BaseFragment
+import com.woowahan.android10.deliverbanchan.presentation.cart.CartActivity
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.showToast
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.toGone
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.toVisible
@@ -105,8 +106,7 @@ class SideDishFragment: BaseFragment<FragmentSidedishBinding>(R.layout.fragment_
                                         "SideDishFragment",
                                         "move to cart, hash : ${hash}, title : ${title}"
                                     )
-                                    // CartActivity 이동 하면서 title, hash 전달 예정
-
+                                    startActivity(Intent(requireActivity(), CartActivity::class.java))
                                 }
                             })
 

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/soupdish/SoupDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/soupdish/SoupDishFragment.kt
@@ -13,6 +13,7 @@ import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.FragmentSoupdishBinding
 import com.woowahan.android10.deliverbanchan.presentation.state.UiState
 import com.woowahan.android10.deliverbanchan.presentation.base.BaseFragment
+import com.woowahan.android10.deliverbanchan.presentation.cart.CartActivity
 import com.woowahan.android10.deliverbanchan.presentation.view.SortSpinnerAdapter
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.showToast
 import com.woowahan.android10.deliverbanchan.presentation.common.ext.toGone
@@ -108,8 +109,7 @@ class SoupDishFragment: BaseFragment<FragmentSoupdishBinding>(R.layout.fragment_
                                         "SoupDishFragment",
                                         "move to cart, hash : ${hash}, title : ${title}"
                                     )
-                                    // CartActivity 이동 하면서 title, hash 전달 예정
-
+                                    startActivity(Intent(requireActivity(), CartActivity::class.java))
                                 }
                             })
 


### PR DESCRIPTION
- 상세 화면에서 주문하기 버튼 누를 시 -> todo : Cart DB 작업 수행
- 위 동작 성공/실패 처리 구현
- 메인 화면 탭별 다이얼로그에서 '장바구니 확인' 누를 시 CartActivity로 이동하도록 추가