### PR TITLE
[FIX] 메인 요리 카트 아이콘 업데이트 로직 수정

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
@@ -81,7 +81,6 @@ class MainDishFragment :
                 cartBottomSheetFragment.setDialogDismissWhenInsertSuccessListener(object :
                     CartBottomSheetFragment.DialogDismissWhenInsertSuccessListener {
                     override fun dialogDismissWhenInsertSuccess(hash: String, title: String) {
-                        mainDishViewModel.changeMainDishItemIsInserted(hash)
                         val cartDialog = CartDialogFragment()
 
                         cartDialog.setTextClickListener(object :


### PR DESCRIPTION
- SoupViewModel과 동일 로직
- 기존 : BottomSheet에서 장바구니 담기 성공 시 명시적으로 해당 아이템의 아이콘을 업데이트 시킴
- 수정 : Cart DB 의 변화를 감지해 변화가 일어나는 경우 현재 아이템 리스트와 비교를 통해 아이콘을 업데이트 시킴