### PR TITLE
[FIX] 카트 리싸이클러뷰 딜리트 버튼 오류 수정

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/cart/CartViewModel.kt
@@ -223,6 +223,7 @@ class CartViewModel @Inject constructor(
     }
 
     fun deleteUiCartItemByPos(position: Int, hash: String) {
+        if (position == -1) return // 클릭했을때, 없어진 view의 경우 position == -1
         _toBeDeletedCartItem.add(hash)
         _uiCartJoinArrayList.removeAt(position)
         _uiCartJoinList.value = _uiCartJoinArrayList

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/cart/main/CartMainFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/cart/main/CartMainFragment.kt
@@ -73,7 +73,7 @@ class CartMainFragment : BaseFragment<FragmentCartMainBinding>(
                     cartViewModel.changeCheckedState(!checkedState)
                 }
             }
-        cartTopBodyAdapter.onClickItemClickListener =
+        cartTopBodyAdapter.onCartTopBodyItemClickListener =
             object : CartDishTopBodyAdapter.OnCartTopBodyItemClickListener {
                 override fun onClickDeleteBtn(position: Int, hash: String) {
                     cartViewModel.deleteUiCartItemByPos(position, hash)

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/cart/main/adapter/CartDishTopBodyAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/cart/main/adapter/CartDishTopBodyAdapter.kt
@@ -3,12 +3,16 @@ package com.woowahan.android10.deliverbanchan.presentation.cart.main.adapter
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.woowahan.android10.deliverbanchan.databinding.ItemCartDishTopBodyBinding
 import com.woowahan.android10.deliverbanchan.domain.model.UiCartJoinItem
+import com.woowahan.android10.deliverbanchan.presentation.common.ext.setClickEventWithDuration
 import dagger.hilt.android.scopes.ActivityRetainedScoped
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 
 @ActivityRetainedScoped
@@ -21,7 +25,7 @@ class CartDishTopBodyAdapter @Inject constructor(
         fun onClickAmountBtn(position: Int, hash: String, amount: Int)
     }
 
-    var onClickItemClickListener: OnCartTopBodyItemClickListener? = null
+    var onCartTopBodyItemClickListener: OnCartTopBodyItemClickListener? = null
 
     companion object {
         const val TAG = "CartDishTopBodyAdapter"
@@ -42,7 +46,7 @@ class CartDishTopBodyAdapter @Inject constructor(
         }
     }
 
-    inner class ViewHolder(val binding: ItemCartDishTopBodyBinding) :
+    inner class ViewHolder(val binding: ItemCartDishTopBodyBinding, private val coroutineScope: CoroutineScope) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(uiCartJoinItem: UiCartJoinItem) {
             with(binding) {
@@ -51,18 +55,18 @@ class CartDishTopBodyAdapter @Inject constructor(
                 val amount = uiCartJoinItem.amount
                 cartSelectTopBodyCb.setOnClickListener {
                     Log.e(TAG, "bind: 체크박스 아이템 클릭=")
-                    onClickItemClickListener?.onCheckBoxCheckedChanged(
+                    onCartTopBodyItemClickListener?.onCheckBoxCheckedChanged(
                         adapterPosition,
                         hash,
                         uiCartJoinItem.checked
                     )
                 }
-                cartSelectTopBodyIbDelete.setOnClickListener {
-                    onClickItemClickListener?.onClickDeleteBtn(adapterPosition, hash)
+                cartSelectTopBodyIbDelete.setClickEventWithDuration(coroutineScope) {
+                    onCartTopBodyItemClickListener?.onClickDeleteBtn(adapterPosition, hash)
                 }
                 cartSelectTopBodyIbMinus.setOnClickListener {
                     if (amount > 1) {
-                        onClickItemClickListener?.onClickAmountBtn(
+                        onCartTopBodyItemClickListener?.onClickAmountBtn(
                             adapterPosition,
                             hash,
                             amount - 1
@@ -70,7 +74,7 @@ class CartDishTopBodyAdapter @Inject constructor(
                     }
                 }
                 cartSelectTopBodyIbPlus.setOnClickListener {
-                    onClickItemClickListener?.onClickAmountBtn(adapterPosition, hash, amount + 1)
+                    onCartTopBodyItemClickListener?.onClickAmountBtn(adapterPosition, hash, amount + 1)
                 }
                 executePendingBindings()
             }
@@ -80,7 +84,7 @@ class CartDishTopBodyAdapter @Inject constructor(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding =
             ItemCartDishTopBodyBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return ViewHolder(binding)
+        return ViewHolder(binding, parent.findViewTreeLifecycleOwner()!!.lifecycleScope)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/cart/main/adapter/CartOrderInfoBottomBodyAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/cart/main/adapter/CartOrderInfoBottomBodyAdapter.kt
@@ -3,10 +3,14 @@ package com.woowahan.android10.deliverbanchan.presentation.cart.main.adapter
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import com.woowahan.android10.deliverbanchan.databinding.ItemCartOrderInfoBottomBodyBinding
 import com.woowahan.android10.deliverbanchan.presentation.cart.model.UiCartBottomBody
+import com.woowahan.android10.deliverbanchan.presentation.common.ext.setClickEventWithDuration
 import dagger.hilt.android.scopes.ActivityRetainedScoped
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 
 @ActivityRetainedScoped
@@ -24,13 +28,13 @@ class CartOrderInfoBottomBodyAdapter @Inject constructor() :
 
     var bottomBodyList: List<UiCartBottomBody> = List(1){UiCartBottomBody.emptyItem ()}
 
-    inner class ViewHolder(val binding: ItemCartOrderInfoBottomBodyBinding) :
+    inner class ViewHolder(val binding: ItemCartOrderInfoBottomBodyBinding, private val coroutineScope: CoroutineScope) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(uiCartBottomBody: UiCartBottomBody) {
             with(binding){
                 Log.e(TAG, "bind: ${uiCartBottomBody.isAvailableDelivery} ${uiCartBottomBody.isAvailableFreeDelivery}")
                 item = uiCartBottomBody
-                cartOrderBottomBodyBtnOrder.setOnClickListener{
+                cartOrderBottomBodyBtnOrder.setClickEventWithDuration(coroutineScope){
                     onCartBottomBodyItemClickListener?.onClickOrderBtn()
                 }
                 executePendingBindings()
@@ -41,7 +45,7 @@ class CartOrderInfoBottomBodyAdapter @Inject constructor() :
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding =
             ItemCartOrderInfoBottomBodyBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return ViewHolder(binding)
+        return ViewHolder(binding, parent.findViewTreeLifecycleOwner()!!.lifecycleScope)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {


### PR DESCRIPTION
* 아이템 딜리트 -> 포지션 -1 값으로 변경 -> 해당 아이템이 없어질때 재클릭 -> position -1에 해당하는 리스트 접근 -> 오류났음
* 이것을 position값이 -1이 들어왔을때 예외처리 해주었음.