### PR TITLE
[FEAT] 모든 메인 탭 에러 대응 적용 및 네트워크 재연결 후 에러 상태인 탭 이동시 자동으로 데이터 다시 로드하도록 구현

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionFragment.kt
@@ -93,6 +93,7 @@ class ExhibitionFragment :
                 binding.errorLayout.errorCl.toGone()
             }
             is ExhibitionUiState.Success -> {
+                Log.e(TAG, "exhibition success")
                 binding.exhibitionPb.toGone()
                 binding.exhibitionRv.toVisible()
                 exhibitionAdapter.submitList(state.uiExhibitionItems)

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionFragment.kt
@@ -41,6 +41,11 @@ class ExhibitionFragment :
         initView()
     }
 
+    override fun onResume() {
+        super.onResume()
+        checkErrorState()
+    }
+
     private fun initView() {
         setExhibitionHeaderAdpater()
         setExhibitionContentAdapter()
@@ -84,25 +89,33 @@ class ExhibitionFragment :
     private fun handleStateChange(state: ExhibitionUiState) {
         when (state) {
             is ExhibitionUiState.IsLoading -> {
-                binding.maindishPb.toVisible()
-                binding.errorCl.toGone()
+                binding.exhibitionPb.toVisible()
+                binding.errorLayout.errorCl.toGone()
             }
             is ExhibitionUiState.Success -> {
-                binding.maindishPb.toGone()
+                binding.exhibitionPb.toGone()
                 binding.exhibitionRv.toVisible()
                 exhibitionAdapter.submitList(state.uiExhibitionItems)
             }
             is ExhibitionUiState.ShowToast -> {
-                binding.maindishPb.toGone()
-                binding.exhibitionRv.toGone()
-                binding.errorCl.toVisible()
                 requireContext().showToast(state.message)
+            }
+            is ExhibitionUiState.Error -> {
+                binding.exhibitionPb.toGone()
+                binding.exhibitionRv.toGone()
+                binding.errorLayout.errorCl.toVisible()
             }
         }
     }
 
     private fun setErrorBtn() {
-        binding.errorBtn.setOnClickListener {
+        binding.errorLayout.errorBtn.setOnClickListener {
+            exhibitionViewModel.getExhibitionList()
+        }
+    }
+
+    private fun checkErrorState() {
+        if (exhibitionViewModel.exhibitionState.value is ExhibitionUiState.Error) {
             exhibitionViewModel.getExhibitionList()
         }
     }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/ExhibitionViewModel.kt
@@ -40,7 +40,7 @@ class ExhibitionViewModel @Inject constructor(
             }.catch { exception ->
                 hideLoading()
                 showToast(exception.message.toString())
-                setError(1)
+                catchError(1)
                 Log.e("ExhibitionViewModel", "error catch!")
             }.flowOn(Dispatchers.IO).collect { result ->
                 hideLoading()
@@ -50,7 +50,7 @@ class ExhibitionViewModel @Inject constructor(
                             exhibitionList = result.data
                             _exhibitionState.value = ExhibitionUiState.Success(result.data)
                         }
-                        is BaseResult.Error -> setError(result.errorCode)
+                        is BaseResult.Error -> catchError(result.errorCode)
                     }
                 }
             }
@@ -88,7 +88,7 @@ class ExhibitionViewModel @Inject constructor(
         _exhibitionState.value = ExhibitionUiState.ShowToast(message)
     }
 
-    private fun setError(errorCode: Int) { // 함수명 더 나은것이 있을까..
+    private fun catchError(errorCode: Int) { // 함수명 더 나은것이 있을까..
         _exhibitionState.value = ExhibitionUiState.Error(errorCode)
     }
 }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
@@ -169,13 +169,12 @@ class MainDishFragment :
                 mainDishLinearAdapter.submitList(state.uiDishItems)
             }
             is UiState.ShowToast -> {
-                binding.maindishPb.toGone()
-                binding.maindishCdl.toGone()
-                binding.errorLayout.errorCl.toVisible()
                 requireContext().showToast(state.message)
             }
             is UiState.Error -> {
-
+                binding.maindishPb.toGone()
+                binding.maindishCdl.toGone()
+                binding.errorLayout.errorCl.toVisible()
             }
         }
     }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
@@ -20,6 +20,7 @@ import com.woowahan.android10.deliverbanchan.presentation.common.ext.toVisible
 import com.woowahan.android10.deliverbanchan.presentation.detail.DetailActivity
 import com.woowahan.android10.deliverbanchan.presentation.dialogs.bottomsheet.CartBottomSheetFragment
 import com.woowahan.android10.deliverbanchan.presentation.main.common.MainGridAdapter
+import com.woowahan.android10.deliverbanchan.presentation.state.ExhibitionUiState
 import com.woowahan.android10.deliverbanchan.presentation.state.UiState
 import com.woowahan.android10.deliverbanchan.presentation.view.SpinnerEventListener
 import com.woowahan.android10.deliverbanchan.presentation.view.adapter.SortSpinnerAdapter
@@ -76,6 +77,7 @@ class MainDishFragment :
         setRadioGroupListener()
         setRecyclerView()
         setSpinnerAdapter()
+        setErrorBtn()
         initObserver()
     }
 
@@ -83,6 +85,7 @@ class MainDishFragment :
         super.onResume()
         Log.e(TAG, "viewLifecycleOwner: ${viewLifecycleOwner}")
         Log.e(TAG, "lifecycleScope: ${viewLifecycleOwner.lifecycleScope}")
+        checkErrorState()
     }
 
     private fun setRadioGroupListener() {
@@ -155,16 +158,37 @@ class MainDishFragment :
 
     private fun handleStateChange(state: UiState) {
         when (state) {
-            is UiState.IsLoading -> binding.maindishPb.toVisible()
+            is UiState.IsLoading -> {
+                binding.maindishPb.toVisible()
+                binding.errorLayout.errorCl.toGone()
+            }
             is UiState.Success -> {
                 binding.maindishPb.toGone()
+                binding.maindishCdl.toVisible()
                 mainDishAdapter.submitList(state.uiDishItems)
                 mainDishLinearAdapter.submitList(state.uiDishItems)
             }
             is UiState.ShowToast -> {
                 binding.maindishPb.toGone()
+                binding.maindishCdl.toGone()
+                binding.errorLayout.errorCl.toVisible()
                 requireContext().showToast(state.message)
             }
+            is UiState.Error -> {
+
+            }
+        }
+    }
+
+    private fun setErrorBtn() {
+        binding.errorLayout.errorBtn.setOnClickListener {
+            mainDishViewModel.getMainDishList()
+        }
+    }
+
+    private fun checkErrorState() {
+        if (mainDishViewModel.mainDishState.value is UiState.Error) {
+            mainDishViewModel.getMainDishList()
         }
     }
 }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishViewModel.kt
@@ -9,6 +9,7 @@ import com.woowahan.android10.deliverbanchan.data.remote.model.response.BaseResu
 import com.woowahan.android10.deliverbanchan.domain.model.UiDishItem
 import com.woowahan.android10.deliverbanchan.domain.usecase.CreateUiDishItemsUseCase
 import com.woowahan.android10.deliverbanchan.domain.usecase.GetAllCartInfoHashSetUseCase
+import com.woowahan.android10.deliverbanchan.presentation.state.ExhibitionUiState
 import com.woowahan.android10.deliverbanchan.presentation.state.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
@@ -60,6 +61,7 @@ class MainDishViewModel @Inject constructor(
                 hideLoading()
                 Log.e("MainDishViewModel", "exception : ${exception.message}")
                 showToast(exception.message.toString())
+                catchError(1)
             }.collect { result ->
                 hideLoading()
                 withContext(Dispatchers.Main) {
@@ -68,8 +70,7 @@ class MainDishViewModel @Inject constructor(
                             mainDishList = result.data
                             _mainDishState.value = UiState.Success(result.data)
                         }
-                        is BaseResult.Error -> _mainDishState.value =
-                            UiState.Error(result.errorCode)
+                        is BaseResult.Error -> catchError(1)
                     }
                 }
             }
@@ -86,6 +87,10 @@ class MainDishViewModel @Inject constructor(
 
     private fun showToast(message: String) {
         _mainDishState.value = UiState.ShowToast(message)
+    }
+
+    private fun catchError(errorCode: Int) {
+        _mainDishState.value = UiState.Error(errorCode)
     }
 
     fun sortMainDishes(position: Int) {

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishViewModel.kt
@@ -52,6 +52,7 @@ class MainDishViewModel @Inject constructor(
     }
 
     fun getMainDishList() {
+        Log.e("MainDishViewModel", "getMainDishList")
         viewModelScope.launch {
             createUiDishItemsUseCase("main").onStart {
                 setLoading()

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/sidedish/SideDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/sidedish/SideDishFragment.kt
@@ -29,11 +29,14 @@ class SideDishFragment :
     BaseFragment<FragmentSidedishBinding>(R.layout.fragment_sidedish, "SideDishFragment") {
 
     private val sideDishViewModel: SideDishViewModel by activityViewModels()
+
     @Inject
     lateinit var sideDishAdapter: MainGridAdapter
+
     @Inject
     lateinit var sideDishSpinnerAdapter: SortSpinnerAdapter
-    @Inject lateinit var gridSpanCountTwoDecorator: GridSpanCountTwoDecorator
+    @Inject
+    lateinit var gridSpanCountTwoDecorator: GridSpanCountTwoDecorator
     private val itemSelectedListener = object : AdapterView.OnItemSelectedListener {
         override fun onItemSelected(
             p0: AdapterView<*>?,
@@ -59,8 +62,9 @@ class SideDishFragment :
 
     override fun onResume() {
         super.onResume()
-        Log.e(TAG, "viewLifecycleOwner: ${viewLifecycleOwner}", )
-        Log.e(TAG, "lifecycleScope: ${viewLifecycleOwner.lifecycleScope}", )
+        Log.e(TAG, "viewLifecycleOwner: ${viewLifecycleOwner}")
+        Log.e(TAG, "lifecycleScope: ${viewLifecycleOwner.lifecycleScope}")
+        checkErrorState()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -68,6 +72,7 @@ class SideDishFragment :
         binding.vm = sideDishViewModel
         initLayout()
         initObserver()
+        setErrorBtn()
     }
 
     private fun initObserver() {
@@ -82,14 +87,22 @@ class SideDishFragment :
 
     private fun handleStateChange(state: UiState) {
         when (state) {
-            is UiState.IsLoading -> binding.sideDishPb.toVisible()
+            is UiState.IsLoading -> {
+                binding.sideDishPb.toVisible()
+                binding.errorLayout.errorCl.toGone()
+            }
             is UiState.Success -> {
                 binding.sideDishPb.toGone()
+                binding.sideDishCdl.toVisible()
                 sideDishAdapter.submitList(state.uiDishItems)
             }
             is UiState.ShowToast -> {
-                binding.sideDishPb.toGone()
                 requireContext().showToast(state.message)
+            }
+            is UiState.Error -> {
+                binding.sideDishPb.toGone()
+                binding.sideDishCdl.toGone()
+                binding.errorLayout.errorCl.toVisible()
             }
         }
     }
@@ -109,6 +122,18 @@ class SideDishFragment :
                     onItemSelectedListener = itemSelectedListener
                 }
             }
+        }
+    }
+
+    private fun setErrorBtn() {
+        binding.errorLayout.errorBtn.setOnClickListener {
+            sideDishViewModel.getSideDishList()
+        }
+    }
+
+    private fun checkErrorState() {
+        if (sideDishViewModel.sideState.value is UiState.Error) {
+            sideDishViewModel.getSideDishList()
         }
     }
 }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/sidedish/SideDishViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/sidedish/SideDishViewModel.kt
@@ -39,6 +39,10 @@ class SideDishViewModel @Inject constructor(
         _sideState.value = UiState.ShowToast(message)
     }
 
+    private fun catchError(errorCode: Int) {
+        _sideState.value = UiState.Error(errorCode)
+    }
+
     init {
         getSideDishList()
         setSideDishCartInserted()
@@ -59,13 +63,14 @@ class SideDishViewModel @Inject constructor(
         }
     }
 
-    private fun getSideDishList() = viewModelScope.launch {
+    fun getSideDishList() = viewModelScope.launch {
         Log.e("SideDishViewModel", "getSideDishList")
         getSideDishListUseCase("side").onStart {
             setLoading()
         }.catch { exception ->
             hideLoading()
             showToast(exception.message.toString())
+            catchError(1)
         }.flowOn(Dispatchers.IO).collect { result ->
             hideLoading()
             when (result) {
@@ -73,7 +78,7 @@ class SideDishViewModel @Inject constructor(
                     _sideState.value = UiState.Success(result.data)
                     sideListSize.value = result.data.size
                 }
-                is BaseResult.Error -> _sideState.value = UiState.Error(result.errorCode)
+                is BaseResult.Error -> catchError(result.errorCode)
             }
         }
     }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/sidedish/SideDishViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/sidedish/SideDishViewModel.kt
@@ -1,5 +1,6 @@
 package com.woowahan.android10.deliverbanchan.presentation.main.sidedish
 
+import android.util.Log
 import androidx.lifecycle.*
 import com.woowahan.android10.deliverbanchan.data.remote.model.response.BaseResult
 import com.woowahan.android10.deliverbanchan.domain.model.UiDishItem
@@ -59,6 +60,7 @@ class SideDishViewModel @Inject constructor(
     }
 
     private fun getSideDishList() = viewModelScope.launch {
+        Log.e("SideDishViewModel", "getSideDishList")
         getSideDishListUseCase("side").onStart {
             setLoading()
         }.catch { exception ->

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/soupdish/SoupDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/soupdish/SoupDishFragment.kt
@@ -26,25 +26,32 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SoupDishFragment: BaseFragment<FragmentSoupdishBinding>(R.layout.fragment_soupdish, "SoupDishFragment") {
+class SoupDishFragment :
+    BaseFragment<FragmentSoupdishBinding>(R.layout.fragment_soupdish, "SoupDishFragment") {
 
     private val dishViewModel: DishViewModel by activityViewModels()
     private val soupViewModel: SoupViewModel by activityViewModels()
-    @Inject lateinit var mainGridAdapter: MainGridAdapter
-    @Inject lateinit var soupSpinnerAdapter: SortSpinnerAdapter
-    @Inject lateinit var gridSpanCountTwoDecorator: GridSpanCountTwoDecorator
-    private val itemSelectedListener = object : AdapterView.OnItemSelectedListener{
+
+    @Inject
+    lateinit var mainGridAdapter: MainGridAdapter
+
+    @Inject
+    lateinit var soupSpinnerAdapter: SortSpinnerAdapter
+
+    @Inject
+    lateinit var gridSpanCountTwoDecorator: GridSpanCountTwoDecorator
+    private val itemSelectedListener = object : AdapterView.OnItemSelectedListener {
         override fun onItemSelected(
             p0: AdapterView<*>?,
             p1: View?,
             position: Int,
             id: Long
         ) {
-            with(soupViewModel){
+            with(soupViewModel) {
                 sortSoupDishes(position)
-                with(soupSpinnerAdapter){
+                with(soupSpinnerAdapter) {
                     sortSpinnerList[curSoupSpinnerPosition.value!!].selected = true
-                    if (curSoupSpinnerPosition.value!=preSoupSpinnerPosition.value){
+                    if (curSoupSpinnerPosition.value != preSoupSpinnerPosition.value) {
                         sortSpinnerList[preSoupSpinnerPosition.value!!].selected = false
                     }
                     notifyDataSetChanged()
@@ -59,22 +66,24 @@ class SoupDishFragment: BaseFragment<FragmentSoupdishBinding>(R.layout.fragment_
 
     override fun onResume() {
         super.onResume()
-        Log.e(TAG, "viewLifecycleOwner: ${viewLifecycleOwner}", )
-        Log.e(TAG, "lifecycleScope: ${viewLifecycleOwner.lifecycleScope}", )
+        Log.e(TAG, "viewLifecycleOwner: ${viewLifecycleOwner}")
+        Log.e(TAG, "lifecycleScope: ${viewLifecycleOwner.lifecycleScope}")
+        checkErrorState()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.vm = soupViewModel
         initLayout()
+        setErrorBtn()
         initObserver()
     }
 
     private fun initObserver() {
-        with(soupViewModel){
+        with(soupViewModel) {
             soupState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
                 .onEach { state ->
-                    Log.e(TAG, "initObserver: $state", )
+                    Log.e(TAG, "initObserver: $state")
                     handleStateChange(state)
                 }.launchIn(lifecycleScope)
 
@@ -82,35 +91,55 @@ class SoupDishFragment: BaseFragment<FragmentSoupdishBinding>(R.layout.fragment_
     }
 
     private fun handleStateChange(state: UiState) {
-        // todo state 에 따른 처리 추가 구현 필요함
-        when(state){
-            is UiState.IsLoading -> binding.soupPb.toVisible()
+        when (state) {
+            is UiState.IsLoading -> {
+                binding.soupPb.toVisible()
+                binding.errorLayout.errorCl.toGone()
+            }
             is UiState.Success -> {
                 binding.soupPb.toGone()
+                binding.soupCdl.toVisible()
                 mainGridAdapter.submitList(state.uiDishItems)
             }
             is UiState.ShowToast -> {
-                binding.soupPb.toGone()
+                Log.e("SoupDishFragment", "show toast")
                 requireContext().showToast(state.message)
+            }
+            is UiState.Error -> {
+                binding.soupPb.toGone()
+                binding.soupCdl.toGone()
+                binding.errorLayout.errorCl.toVisible()
             }
         }
     }
 
     private fun initLayout() {
-        with(binding){
-            with(soupDishRv){
+        with(binding) {
+            with(soupDishRv) {
                 adapter = mainGridAdapter.apply {
                     onDishItemClickListener = this@SoupDishFragment
                 }
                 if (itemDecorationCount == 0) addItemDecoration(gridSpanCountTwoDecorator)
             }
-            with(soupDishSp){
+            with(soupDishSp) {
                 setWillNotDraw(false)
                 adapter = soupSpinnerAdapter.apply {
                     setSpinnerEventsListener(SpinnerEventListener(requireContext()))
                     onItemSelectedListener = itemSelectedListener
                 }
             }
+        }
+    }
+
+    private fun setErrorBtn() {
+        binding.errorLayout.errorBtn.setOnClickListener {
+            soupViewModel.setSoupDishesState()
+        }
+    }
+
+    private fun checkErrorState() {
+        if (soupViewModel.soupState.value is UiState.Error) {
+            soupViewModel.setSoupDishesState()
         }
     }
 }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/soupdish/SoupViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/soupdish/SoupViewModel.kt
@@ -43,7 +43,7 @@ class SoupViewModel @Inject constructor(
         // cart flow collect 시 , 장바구니 insert 여부 확인함
         viewModelScope.launch {
             getAllCartInfoSetUseCase().collect { cartInfoHashSet ->
-                if (_soupState.value is UiState.Success){
+                if (_soupState.value is UiState.Success) {
                     val tempList = mutableListOf<UiDishItem>()
                     (_soupState.value as UiState.Success).uiDishItems.forEach {
                         tempList.add(it.copy(isInserted = cartInfoHashSet.contains(it.hash)))
@@ -66,22 +66,29 @@ class SoupViewModel @Inject constructor(
         _soupState.value = UiState.ShowToast(message)
     }
 
-    private fun setSoupDishesState() = viewModelScope.launch {
-        Log.e("SoupViewModel", "getSoupList")
-        getSoupDishesUseCase("soup").onStart {
-            setLoadingStateTrue()
-        }.catch { exception ->
-            Log.e(TAG, "getSoupDishes: $exception", )
-            setLoadingStateFalse()
-            setToastMessageByException(exception.message.toString())
-        }.flowOn(Dispatchers.IO).collect { result ->
-            setLoadingStateFalse()
-            when (result) {
-                is BaseResult.Success -> {
-                    _soupState.value = UiState.Success(result.data)
-                    soupListSize.value = result.data.size
+    private fun catchError(errorCode: Int) {
+        _soupState.value = UiState.Error(errorCode)
+    }
+
+    fun setSoupDishesState() {
+        viewModelScope.launch {
+            Log.e("SoupViewModel", "getSoupList")
+            getSoupDishesUseCase("soup").onStart {
+                setLoadingStateTrue()
+            }.catch { exception ->
+                Log.e(TAG, "getSoupDishes: $exception")
+                setLoadingStateFalse()
+                setToastMessageByException(exception.message.toString())
+                catchError(1)
+            }.flowOn(Dispatchers.IO).collect { result ->
+                setLoadingStateFalse()
+                when (result) {
+                    is BaseResult.Success -> {
+                        _soupState.value = UiState.Success(result.data)
+                        soupListSize.value = result.data.size
+                    }
+                    is BaseResult.Error -> catchError(result.errorCode)
                 }
-                is BaseResult.Error -> _soupState.value = UiState.Error(result.errorCode)
             }
         }
     }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/soupdish/SoupViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/soupdish/SoupViewModel.kt
@@ -67,6 +67,7 @@ class SoupViewModel @Inject constructor(
     }
 
     private fun setSoupDishesState() = viewModelScope.launch {
+        Log.e("SoupViewModel", "getSoupList")
         getSoupDishesUseCase("soup").onStart {
             setLoadingStateTrue()
         }.catch { exception ->

--- a/app/src/main/res/layout/fragment_exhibition.xml
+++ b/app/src/main/res/layout/fragment_exhibition.xml
@@ -18,7 +18,7 @@
             app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
         <ProgressBar
-            android:id="@+id/maindish_pb"
+            android:id="@+id/exhibition_pb"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -29,54 +29,9 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/error_cl"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone">
-
-            <TextView
-                android:id="@+id/error_tv"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:maxLines="1"
-                android:text="화면을 불러오지 못했어요."
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.4" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/error_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="15dp"
-                android:backgroundTint="@color/white"
-                android:fontFamily="@font/noto_sans_kr_medium_500"
-                android:text="다시 시도하기"
-                android:textColor="@color/grey_scale_default"
-                android:textSize="14sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/error_tv"
-                app:shapeAppearanceOverlay="@style/cardViewRadius"
-                app:strokeColor="@color/grey_scale_line"
-                app:strokeWidth="1dp" />
-
-            <ImageView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="50dp"
-                android:adjustViewBounds="true"
-                android:scaleType="fitXY"
-                android:src="@drawable/image_error"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/error_btn"
-                app:layout_constraintWidth_percent="0.4" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <include
+            android:id="@+id/error_layout"
+            layout="@layout/layout_error_screen" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_maindish.xml
+++ b/app/src/main/res/layout/fragment_maindish.xml
@@ -6,116 +6,127 @@
 
     </data>
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.google.android.material.appbar.AppBarLayout
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/maindish_cdl"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@color/white">
+            android:layout_height="match_parent">
 
-            <com.google.android.material.appbar.CollapsingToolbarLayout
+            <com.google.android.material.appbar.AppBarLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+                android:backgroundTint="@color/white">
 
-                <androidx.constraintlayout.widget.ConstraintLayout
+                <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="24dp">
+                    app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
                     <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/maindish_cl_header_text"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:background="@color/primary_surface"
-                        app:layout_constraintTop_toTopOf="parent">
+                        android:layout_marginBottom="24dp">
 
-                        <TextView
-                            android:id="@+id/maindish_tv_header"
-                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
-                            android:layout_width="wrap_content"
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/maindish_cl_header_text"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/base_space_16dp"
-                            android:layout_marginTop="53dp"
-                            android:layout_marginBottom="53dp"
-                            android:text="@string/main_header_main_dish"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
-
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/maindish_cl_header_filter"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="24dp"
-                        app:layout_constraintTop_toBottomOf="@id/maindish_cl_header_text">
-
-                        <RadioGroup
-                            android:id="@+id/maindish_rg"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/base_space_16dp"
-                            android:orientation="horizontal"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
+                            android:background="@color/primary_surface"
                             app:layout_constraintTop_toTopOf="parent">
 
-                            <androidx.appcompat.widget.AppCompatRadioButton
-                                android:id="@+id/maindish_rb_grid"
-                                android:layout_width="24dp"
-                                android:layout_height="24dp"
-                                android:background="@drawable/selector_maindish_grid"
-                                android:button="@null"
-                                android:checked="true" />
+                            <TextView
+                                android:id="@+id/maindish_tv_header"
+                                style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="@dimen/base_space_16dp"
+                                android:layout_marginTop="53dp"
+                                android:layout_marginBottom="53dp"
+                                android:text="@string/main_header_main_dish"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
 
-                            <androidx.appcompat.widget.AppCompatRadioButton
-                                android:id="@+id/maindish_rb_linear"
-                                android:layout_width="24dp"
-                                android:layout_height="24dp"
-                                android:background="@drawable/selector_maindish_linear"
-                                android:button="@null" />
-                        </RadioGroup>
+                        </androidx.constraintlayout.widget.ConstraintLayout>
 
-                        <com.woowahan.android10.deliverbanchan.presentation.view.CustomSortingSpinner
-                            android:id="@+id/main_dish_sp"
-                            android:layout_width="145dp"
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/maindish_cl_header_filter"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginEnd="@dimen/base_space_16dp"
-                            app:verticalOffsetDpValue="@dimen/cart_btn_width_32dp"
-                            android:background="@drawable/bg_sort_spinner_down"
-                            android:popupBackground="@drawable/bg_sort_spinner_pop_up"
-                            android:popupElevation="@dimen/rv_space_4dp"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            app:layout_constraintBottom_toBottomOf="parent"/>
+                            android:layout_marginTop="24dp"
+                            app:layout_constraintTop_toBottomOf="@id/maindish_cl_header_text">
+
+                            <RadioGroup
+                                android:id="@+id/maindish_rg"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="@dimen/base_space_16dp"
+                                android:orientation="horizontal"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent">
+
+                                <androidx.appcompat.widget.AppCompatRadioButton
+                                    android:id="@+id/maindish_rb_grid"
+                                    android:layout_width="24dp"
+                                    android:layout_height="24dp"
+                                    android:background="@drawable/selector_maindish_grid"
+                                    android:button="@null"
+                                    android:checked="true" />
+
+                                <androidx.appcompat.widget.AppCompatRadioButton
+                                    android:id="@+id/maindish_rb_linear"
+                                    android:layout_width="24dp"
+                                    android:layout_height="24dp"
+                                    android:background="@drawable/selector_maindish_linear"
+                                    android:button="@null" />
+                            </RadioGroup>
+
+                            <com.woowahan.android10.deliverbanchan.presentation.view.CustomSortingSpinner
+                                android:id="@+id/main_dish_sp"
+                                android:layout_width="145dp"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="@dimen/base_space_16dp"
+                                android:background="@drawable/bg_sort_spinner_down"
+                                android:popupBackground="@drawable/bg_sort_spinner_pop_up"
+                                android:popupElevation="@dimen/rv_space_4dp"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toTopOf="parent"
+                                app:verticalOffsetDpValue="@dimen/cart_btn_width_32dp" />
+
+                        </androidx.constraintlayout.widget.ConstraintLayout>
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
-                </androidx.constraintlayout.widget.ConstraintLayout>
+                </com.google.android.material.appbar.CollapsingToolbarLayout>
 
-            </com.google.android.material.appbar.CollapsingToolbarLayout>
+            </com.google.android.material.appbar.AppBarLayout>
 
-        </com.google.android.material.appbar.AppBarLayout>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/maindish_rv"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="@dimen/rv_space_8dp"
+                android:layout_marginEnd="@dimen/base_space_16dp"
+                app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/maindish_rv"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginStart="@dimen/rv_space_8dp"
-            android:layout_marginEnd="@dimen/base_space_16dp"
-            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
+            <ProgressBar
+                android:id="@+id/maindish_pb"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminateBehavior="repeat"
+                android:indeterminateTint="@color/progress_indicator" />
 
-        <ProgressBar
-            android:id="@+id/maindish_pb"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:indeterminateBehavior="repeat"
-            android:indeterminateTint="@color/progress_indicator"
-            android:layout_gravity="center"/>
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+        <include
+            android:id="@+id/error_layout"
+            layout="@layout/layout_error_screen" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_sidedish.xml
+++ b/app/src/main/res/layout/fragment_sidedish.xml
@@ -3,106 +3,119 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <variable
             name="vm"
             type="com.woowahan.android10.deliverbanchan.presentation.main.sidedish.SideDishViewModel" />
     </data>
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/side_dish_cdl"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/side_dish_apl"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/side_dish_cdl"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@color/white">
+            android:layout_height="match_parent">
 
-            <com.google.android.material.appbar.CollapsingToolbarLayout
-                android:id="@+id/side_dish_ctl"
+            <com.google.android.material.appbar.AppBarLayout
+                android:id="@+id/side_dish_apl"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+                android:backgroundTint="@color/white">
 
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:id="@+id/side_dish_cl"
+                <com.google.android.material.appbar.CollapsingToolbarLayout
+                    android:id="@+id/side_dish_ctl"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/rv_space_8dp">
+                    app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
                     <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/side_dish_cl_header_text"
+                        android:id="@+id/side_dish_cl"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:background="@color/primary_surface"
-                        app:layout_constraintTop_toTopOf="parent">
+                        android:layout_marginBottom="@dimen/rv_space_8dp">
 
-                        <TextView
-                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
-                            android:layout_width="wrap_content"
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/side_dish_cl_header_text"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/base_space_16dp"
-                            android:layout_marginTop="53dp"
-                            android:layout_marginBottom="53dp"
-                            android:text="@string/main_header_side_dish"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
+                            android:background="@color/primary_surface"
+                            app:layout_constraintTop_toTopOf="parent">
+
+                            <TextView
+                                style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="@dimen/base_space_16dp"
+                                android:layout_marginTop="53dp"
+                                android:layout_marginBottom="53dp"
+                                android:text="@string/main_header_side_dish"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                        </androidx.constraintlayout.widget.ConstraintLayout>
+
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/side_dish_cl_header_filter"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="24dp"
+                            app:layout_constraintTop_toBottomOf="@id/side_dish_cl_header_text">
+
+                            <TextView
+                                android:id="@+id/soupdish_tv_item_count"
+                                style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.Style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="@dimen/base_space_16dp"
+                                android:text="@{`총 `+ String.valueOf(vm.sideListSize) +`개 상품`}"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                            <com.woowahan.android10.deliverbanchan.presentation.view.CustomSortingSpinner
+                                android:id="@+id/side_dish_sp"
+                                android:layout_width="145dp"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="@dimen/base_space_16dp"
+                                android:background="@drawable/bg_sort_spinner_down"
+                                android:popupBackground="@drawable/bg_sort_spinner_pop_up"
+                                android:popupElevation="@dimen/rv_space_4dp"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toTopOf="parent"
+                                app:verticalOffsetDpValue="@dimen/cart_btn_width_32dp" />
+
+                        </androidx.constraintlayout.widget.ConstraintLayout>
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/side_dish_cl_header_filter"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="24dp"
-                        app:layout_constraintTop_toBottomOf="@id/side_dish_cl_header_text">
+                </com.google.android.material.appbar.CollapsingToolbarLayout>
 
-                        <TextView
-                            android:id="@+id/soupdish_tv_item_count"
-                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.Style"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/base_space_16dp"
-                            android:text="@{`총 `+ String.valueOf(vm.sideListSize) +`개 상품`}"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
-                        <com.woowahan.android10.deliverbanchan.presentation.view.CustomSortingSpinner
-                            android:id="@+id/side_dish_sp"
-                            android:layout_width="145dp"
-                            android:layout_height="wrap_content"
-                            android:layout_marginEnd="@dimen/base_space_16dp"
-                            android:background="@drawable/bg_sort_spinner_down"
-                            app:verticalOffsetDpValue="@dimen/cart_btn_width_32dp"
-                            android:popupBackground="@drawable/bg_sort_spinner_pop_up"
-                            android:popupElevation="@dimen/rv_space_4dp"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            app:layout_constraintBottom_toBottomOf="parent"/>
+            </com.google.android.material.appbar.AppBarLayout>
 
-                    </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/side_dish_rv"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+                app:spanCount="2" />
 
-                </androidx.constraintlayout.widget.ConstraintLayout>
+            <ProgressBar
+                android:id="@+id/side_dish_pb"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminateBehavior="repeat"
+                android:indeterminateTint="@color/progress_indicator" />
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-            </com.google.android.material.appbar.CollapsingToolbarLayout>
+        <include
+            android:id="@+id/error_layout"
+            layout="@layout/layout_error_screen" />
 
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/side_dish_rv"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:spanCount="2"
-            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
-        <ProgressBar
-            android:id="@+id/side_dish_pb"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:indeterminateBehavior="repeat"
-            android:indeterminateTint="@color/progress_indicator"
-            android:layout_gravity="center"/>
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_soupdish.xml
+++ b/app/src/main/res/layout/fragment_soupdish.xml
@@ -14,6 +14,7 @@
         android:layout_height="match_parent">
 
         <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/soup_cdl"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/fragment_soupdish.xml
+++ b/app/src/main/res/layout/fragment_soupdish.xml
@@ -3,103 +3,115 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <variable
             name="vm"
             type="com.woowahan.android10.deliverbanchan.presentation.main.soupdish.SoupViewModel" />
     </data>
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.google.android.material.appbar.AppBarLayout
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@color/white">
-            <com.google.android.material.appbar.CollapsingToolbarLayout
+            android:layout_height="match_parent">
+
+            <com.google.android.material.appbar.AppBarLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/rv_space_8dp"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+                android:backgroundTint="@color/white">
 
-                <androidx.constraintlayout.widget.ConstraintLayout
+                <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/rv_space_8dp"
+                    app:layout_scrollFlags="scroll|exitUntilCollapsed">
 
                     <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/soup_dish_cl_header_text"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:background="@color/primary_surface"
-                        app:layout_constraintTop_toTopOf="parent">
+                        android:layout_height="wrap_content">
 
-                        <TextView
-                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
-                            android:layout_width="wrap_content"
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/soup_dish_cl_header_text"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/base_space_16dp"
-                            android:layout_marginTop="53dp"
-                            android:layout_marginBottom="53dp"
-                            android:text="@string/main_header_soup_dish"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
+                            android:background="@color/primary_surface"
+                            app:layout_constraintTop_toTopOf="parent">
+
+                            <TextView
+                                style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack32_Normal.Style"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="@dimen/base_space_16dp"
+                                android:layout_marginTop="53dp"
+                                android:layout_marginBottom="53dp"
+                                android:text="@string/main_header_soup_dish"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                        </androidx.constraintlayout.widget.ConstraintLayout>
+
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/soup_dish_cl_header_filter"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="24dp"
+                            app:layout_constraintTop_toBottomOf="@id/soup_dish_cl_header_text">
+
+                            <TextView
+                                android:id="@+id/soup_dish_tv_item_count"
+                                style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.Style"
+                                android:layout_width="0dp"
+                                android:layout_height="15dp"
+                                android:layout_marginStart="@dimen/base_space_16dp"
+                                android:text="@{`총 `+ String.valueOf(vm.soupListSize) +`개 상품`}"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                            <com.woowahan.android10.deliverbanchan.presentation.view.CustomSortingSpinner
+                                android:id="@+id/soup_dish_sp"
+                                android:layout_width="145dp"
+                                android:layout_height="wrap_content"
+                                android:layout_marginEnd="@dimen/base_space_16dp"
+                                android:background="@drawable/bg_sort_spinner_down"
+                                android:popupBackground="@drawable/bg_sort_spinner_pop_up"
+                                android:popupElevation="@dimen/rv_space_4dp"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toTopOf="parent"
+                                app:verticalOffsetDpValue="@dimen/cart_btn_width_32dp" />
+
+                        </androidx.constraintlayout.widget.ConstraintLayout>
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/soup_dish_cl_header_filter"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="24dp"
-                        app:layout_constraintTop_toBottomOf="@id/soup_dish_cl_header_text">
+                </com.google.android.material.appbar.CollapsingToolbarLayout>
 
-                        <TextView
-                            android:id="@+id/soup_dish_tv_item_count"
-                            style="@style/Widget.TextView.NotoSansKR_GreyScaleBlack12_Normal.Style"
-                            android:layout_width="0dp"
-                            android:layout_height="15dp"
-                            android:layout_marginStart="@dimen/base_space_16dp"
-                            android:text="@{`총 `+ String.valueOf(vm.soupListSize) +`개 상품`}"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
+            </com.google.android.material.appbar.AppBarLayout>
 
-                        <com.woowahan.android10.deliverbanchan.presentation.view.CustomSortingSpinner
-                            android:id="@+id/soup_dish_sp"
-                            android:layout_width="145dp"
-                            android:layout_height="wrap_content"
-                            android:layout_marginEnd="@dimen/base_space_16dp"
-                            app:verticalOffsetDpValue="@dimen/cart_btn_width_32dp"
-                            android:background="@drawable/bg_sort_spinner_down"
-                            android:popupBackground="@drawable/bg_sort_spinner_pop_up"
-                            android:popupElevation="@dimen/rv_space_4dp"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            app:layout_constraintBottom_toBottomOf="parent"/>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/soup_dish_rv"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+                app:spanCount="2" />
 
-                    </androidx.constraintlayout.widget.ConstraintLayout>
+            <ProgressBar
+                android:id="@+id/soup_pb"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminateBehavior="repeat"
+                android:indeterminateTint="@color/progress_indicator" />
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
-                </androidx.constraintlayout.widget.ConstraintLayout>
+        <include
+            android:id="@+id/error_layout"
+            layout="@layout/layout_error_screen" />
 
-            </com.google.android.material.appbar.CollapsingToolbarLayout>
-
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/soup_dish_rv"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
-            app:spanCount="2" />
-
-        <ProgressBar
-            android:id="@+id/soup_pb"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:indeterminateBehavior="repeat"
-            android:indeterminateTint="@color/progress_indicator"
-            android:layout_gravity="center"/>
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/layout_error_screen.xml
+++ b/app/src/main/res/layout/layout_error_screen.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/error_cl"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/error_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:text="화면을 불러오지 못했어요."
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.4" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/error_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="15dp"
+            android:backgroundTint="@color/white"
+            android:fontFamily="@font/noto_sans_kr_medium_500"
+            android:text="다시 시도하기"
+            android:textColor="@color/grey_scale_default"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/error_tv"
+            app:shapeAppearanceOverlay="@style/cardViewRadius"
+            app:strokeColor="@color/grey_scale_line"
+            app:strokeWidth="1dp" />
+
+        <ImageView
+            android:id="@+id/error_iv"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="50dp"
+            android:adjustViewBounds="true"
+            android:scaleType="fitXY"
+            android:src="@drawable/image_error"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/error_btn"
+            app:layout_constraintWidth_percent="0.4" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/layout_error_screen.xml
+++ b/app/src/main/res/layout/layout_error_screen.xml
@@ -6,12 +6,10 @@
 
     </data>
 
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/error_cl"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone">
+        android:layout_height="match_parent">
 
         <TextView
             android:id="@+id/error_tv"


### PR DESCRIPTION
- 메인 요리 화면도 에러 화면 적용
- 에러 상태인 탭으로 다시갈때 자동으로 데이터 호출할 수 있도록 설정
  - 해당 탭의 프래그먼트의 onResume에서 현재 uistate가 에러상태인지를 판단하고 데이터를 재호출 하도록 설정
- error layout 생성 -> 필요한 곳에서 include 로 사용하기