### PR TITLE
[FIX] (메인요리 화면 적용) 스피너로 정렬 기준 변경 시 스크롤 내려가는 현상 해결

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_4_API_32.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
     <targetSelectedWithDropDown>
       <Target>
         <type value="QUICK_BOOT_TARGET" />
@@ -12,6 +23,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-08-23T11:30:07.670218Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-08-24T10:21:12.687137Z" />
   </component>
 </project>

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
@@ -65,11 +65,8 @@ class MainDishFragment :
                     Log.e(TAG, "maindish sorted")
                     //binding.maindishRv.smoothScrollToPosition(0)
 
-                    if (isListenerAdd == false) {
+                    if (!isListenerAdd) {
                         isListenerAdd = true
-                        globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
-                            binding.maindishRv.scrollToPosition(0)
-                        }
                         binding.maindishRv.viewTreeObserver.addOnGlobalLayoutListener(
                             globalLayoutListener
                         )
@@ -85,9 +82,15 @@ class MainDishFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
+        initGlobalLayoutListener()
         initView()
         Log.e(TAG, "onViewCreated: ${binding.maindishTvHeader.paintFlags}")
+    }
+
+    private fun initGlobalLayoutListener() {
+        globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+            binding.maindishRv.scrollToPosition(0)
+        }
     }
 
     private fun initView() {
@@ -149,11 +152,11 @@ class MainDishFragment :
             adapter = mainDishAdapter
             layoutManager = GridLayoutManager(requireContext(), 2)
 
-            addOnScrollListener(object: RecyclerView.OnScrollListener(){
+            addOnScrollListener(object : RecyclerView.OnScrollListener() {
                 override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                     super.onScrollStateChanged(recyclerView, newState)
 
-                    if (isListenerAdd == true) {
+                    if (isListenerAdd) {
                         binding.maindishRv.viewTreeObserver.removeOnGlobalLayoutListener(
                             globalLayoutListener
                         )

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/maindish/MainDishFragment.kt
@@ -3,7 +3,9 @@ package com.woowahan.android10.deliverbanchan.presentation.main.maindish
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewTreeObserver
 import android.widget.AdapterView
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -11,6 +13,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.FragmentMaindishBinding
 import com.woowahan.android10.deliverbanchan.presentation.base.BaseFragment
@@ -35,12 +38,14 @@ class MainDishFragment :
     private val mainDishViewModel: MainDishViewModel by viewModels()
     private lateinit var mainDishLinearAdapter: MainDishLinearAdapter
 
-    //private lateinit var mainDishGridAdapter: MainDishGridAdapter
     @Inject
     lateinit var mainDishAdapter: MainGridAdapter
 
     @Inject
     lateinit var mainDishSpinnerAdapter: SortSpinnerAdapter
+
+    var isListenerAdd = false
+    var globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener { }
 
     private val itemSelectedListener = object : AdapterView.OnItemSelectedListener {
         override fun onItemSelected(
@@ -57,6 +62,18 @@ class MainDishFragment :
                         sortSpinnerList[preMainSpinnerPosition.value!!].selected = false
                     }
                     notifyDataSetChanged()
+                    Log.e(TAG, "maindish sorted")
+                    //binding.maindishRv.smoothScrollToPosition(0)
+
+                    if (isListenerAdd == false) {
+                        isListenerAdd = true
+                        globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+                            binding.maindishRv.scrollToPosition(0)
+                        }
+                        binding.maindishRv.viewTreeObserver.addOnGlobalLayoutListener(
+                            globalLayoutListener
+                        )
+                    }
                 }
             }
         }
@@ -131,7 +148,22 @@ class MainDishFragment :
         binding.maindishRv.apply {
             adapter = mainDishAdapter
             layoutManager = GridLayoutManager(requireContext(), 2)
+
+            addOnScrollListener(object: RecyclerView.OnScrollListener(){
+                override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                    super.onScrollStateChanged(recyclerView, newState)
+
+                    if (isListenerAdd == true) {
+                        binding.maindishRv.viewTreeObserver.removeOnGlobalLayoutListener(
+                            globalLayoutListener
+                        )
+                        isListenerAdd = false
+                    }
+                }
+            })
         }
+
+
     }
 
     private fun setSpinnerAdapter() {

--- a/app/src/main/res/layout/layout_error_screen.xml
+++ b/app/src/main/res/layout/layout_error_screen.xml
@@ -9,7 +9,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/error_cl"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:visibility="gone">
 
         <TextView
             android:id="@+id/error_tv"


### PR DESCRIPTION
- ViewTreeObserver.OnGlobalLayoutListener 를 활용
- 위 리스너를 한 번 달아주고, 리사이클러뷰 스크롤 시 해제하는 로직
- 상세 설명은 이슈 #127에 정리
- https://github.com/woowa-techcamp-2022/android-banchan-10/issues/127