### PR TITLE
[FIX] #157 #161 상세화면 상단 이미지 뷰페이저 페이지 상태 유지 및 하단 영역 디자인 요구사항에 맞게 수정

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-08-26T03:41:35.947773Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-08-27T06:05:30.292005Z" />
   </component>
 </project>

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/domain/model/UiDetailInfo.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/domain/model/UiDetailInfo.kt
@@ -26,7 +26,8 @@ data class UiDetailInfo(
             point = "",
             deliveryInfo = "",
             deliveryFee = "",
-            emptyList(), emptyList(),
+            thumbList = emptyList(),
+            detailSection = emptyList(),
             sPrice = 0
         )
     }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailActivity.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailActivity.kt
@@ -2,6 +2,7 @@ package com.woowahan.android10.deliverbanchan.presentation.detail
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -73,7 +74,10 @@ class DetailActivity :
     }
 
     private fun setRecyclerView() {
-        detailThumbImageAdapter = DetailThumbImageAdapter()
+        detailThumbImageAdapter = DetailThumbImageAdapter{ pageNum ->
+            Log.e(TAG, "current image page: ${pageNum}")
+            detailViewModel.changeCurrentThumbImagePage(pageNum)
+        }
         detailContentAdapter = DetailContentAdapter({
             // minus click
             detailViewModel.minusItemCount()
@@ -112,7 +116,12 @@ class DetailActivity :
                     binding.detailErrorLayout.errorCl.toGone()
                     binding.detailRv.toVisible()
                     binding.detailPb.toGone()
-                    detailThumbImageAdapter.submitList(listOf(uiDetailState.items.thumbList))
+                    Log.e("TAG", "UiState.Success")
+
+                    with(detailThumbImageAdapter){
+                        currentImagePage = detailViewModel.currentThumbImagePage
+                        submitList(listOf(uiDetailState.items.thumbList))
+                    }
                     detailContentAdapter.submitList(listOf(uiDetailState.items))
                     detailSectionImageAdapter.submitList(uiDetailState.items.detailSection)
                 }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/DetailViewModel.kt
@@ -32,7 +32,6 @@ class DetailViewModel @Inject constructor(
         const val TAG = "DetailViewModel"
     }
 
-
     val cartIconText = MutableLiveData("")
     val isOrderingExist = MutableLiveData(false)
 
@@ -43,6 +42,8 @@ class DetailViewModel @Inject constructor(
         SharingStarted.WhileSubscribed(5000),
         UiState.Init
     )
+
+    var currentThumbImagePage = 0
 
     private val _itemCount = MutableStateFlow<Int>(1)
     val itemCount: StateFlow<Int> = _itemCount
@@ -59,6 +60,7 @@ class DetailViewModel @Inject constructor(
     }
 
     private fun getAllCartInfo() = viewModelScope.launch {
+        Log.e(TAG, "getAllCartInfo 호출")
         getAllCartInfoUseCase(this).collect { cartInfoList ->
             setCartIconText(cartInfoList.size)
             // 디테일화면에서 insert하고, 다른곳 갔다가 다시 왔을때 카트에 있는것인지 없는것인지 판단하여 수량을 update할지
@@ -184,5 +186,9 @@ class DetailViewModel @Inject constructor(
                 (_uiDetailInfo.value as UiState.Success).items.copy(itemCount = _itemCount.value)
             )
         }
+    }
+
+    fun changeCurrentThumbImagePage(pageNum: Int) {
+        currentThumbImagePage = pageNum
     }
 }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/adapter/DetailSectionImageAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/adapter/DetailSectionImageAdapter.kt
@@ -2,6 +2,7 @@ package com.woowahan.android10.deliverbanchan.presentation.detail.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -12,8 +13,9 @@ class DetailSectionImageAdapter :
 
     inner class DetailSectionViewHolder(private val binding: ItemDetailSectionImageBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(imageUrl: String) {
+        fun bind(imageUrl: String, position: Int) {
             binding.imageUrl = imageUrl
+            binding.detailViewBottom.isVisible = (position == currentList.size - 1)
         }
     }
 
@@ -28,7 +30,7 @@ class DetailSectionImageAdapter :
     }
 
     override fun onBindViewHolder(holder: DetailSectionViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), position)
     }
 
     companion object DetailSectionDiffUtil : DiffUtil.ItemCallback<String>() {

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/adapter/DetailThumbImageAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/detail/adapter/DetailThumbImageAdapter.kt
@@ -6,21 +6,33 @@ import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
 import com.woowahan.android10.deliverbanchan.R
 import com.woowahan.android10.deliverbanchan.databinding.ItemDetailThumbImageRvBinding
 
-class DetailThumbImageAdapter :
+class DetailThumbImageAdapter(
+    private val changeCurrentPage: (pageNum : Int) -> Unit
+) :
     ListAdapter<List<String>, DetailThumbImageAdapter.DetailThumbImageHolder>(
         DetailThumbImageDiffUtil
     ) {
 
+    var currentImagePage = 0
+
     inner class DetailThumbImageHolder(private val binding: ItemDetailThumbImageRvBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(imgUrlList: List<String>) {
+        fun bind(imgUrlList: List<String>, changeCurrentPage: (pageNum: Int) -> Unit) {
             val vpAdapter = DetailThumbViewPagerAdapter()
             binding.detailVpThumb.apply {
                 adapter = vpAdapter
+                registerOnPageChangeCallback(object: ViewPager2.OnPageChangeCallback() {
+                    override fun onPageSelected(position: Int) {
+                        super.onPageSelected(position)
+                        currentImagePage = position
+                        changeCurrentPage(position)
+                    }
+                })
             }
 
             TabLayoutMediator(binding.detailTl, binding.detailVpThumb) { tab, position ->
@@ -34,6 +46,8 @@ class DetailThumbImageAdapter :
                     .inflate(R.layout.tab_indicator, null) as TextView
                 binding.detailTl.getTabAt(index)?.customView = textView
             }
+
+            binding.detailVpThumb.setCurrentItem(currentImagePage, false)
         }
     }
 
@@ -48,7 +62,7 @@ class DetailThumbImageAdapter :
     }
 
     override fun onBindViewHolder(holder: DetailThumbImageHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position), changeCurrentPage)
     }
 
     companion object DetailThumbImageDiffUtil : DiffUtil.ItemCallback<List<String>>() {

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -33,7 +33,8 @@
             android:id="@+id/detail_rv"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1" />
+            android:layout_weight="1"
+            />
 
         <include
             android:id="@+id/detail_error_layout"

--- a/app/src/main/res/layout/item_detail_section_image.xml
+++ b/app/src/main/res/layout/item_detail_section_image.xml
@@ -39,5 +39,11 @@
             app:layout_constraintTop_toTopOf="parent"
             app:setStringUrlImage="@{imageUrl}" />
 
+        <View
+            android:id="@+id/detail_view_bottom"
+            android:layout_width="match_parent"
+            android:layout_height="24dp"
+            app:layout_constraintTop_toBottomOf="@id/detail_iv_section"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- 뷰모델에서 현재 뷰페이저 페이지 상태 가지고 있을 수 있도록 수정
- 하단 이미지 리사이클러뷰에서 마지막 아이템뷰의 경우 하단 영역을 나타낼 empty view를 gone에서 visible로 변경하는 로직 사용