### PR TITLE
[FIX] 기획전 화면 카트 아이콘 업데이트 시 해당 영역 다시 그려지면서 수평 스크롤 초기화되는 현상 해결

### DIFF
--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/adapter/ExhibitionAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/adapter/ExhibitionAdapter.kt
@@ -1,5 +1,6 @@
 package com.woowahan.android10.deliverbanchan.presentation.main.exhibition.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -7,6 +8,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.woowahan.android10.deliverbanchan.databinding.ItemExhibitionBinding
+import com.woowahan.android10.deliverbanchan.domain.model.UiDishItem
 import com.woowahan.android10.deliverbanchan.domain.model.UiExhibitionItem
 import com.woowahan.android10.deliverbanchan.presentation.base.listeners.OnDishItemClickListener
 
@@ -29,6 +31,13 @@ class ExhibitionAdapter() :
             ): Boolean {
                 return newItem == oldItem
             }
+
+            override fun getChangePayload(
+                oldItem: UiExhibitionItem,
+                newItem: UiExhibitionItem
+            ): Any? {
+                return if(oldItem.uiDishItems != newItem.uiDishItems) true else null
+            }
         }
     }
 
@@ -37,30 +46,57 @@ class ExhibitionAdapter() :
     inner class ExhibitionViewHolder(private val binding: ItemExhibitionBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(uiExhibitionItem: UiExhibitionItem) {
+        lateinit var exhibitonHorizontalAdpater: ExhibitionHorizontalAdapter
+
+        fun bind(uiExhibitionItem: UiExhibitionItem, position: Int) {
+            Log.e(TAG, "bind, position : ${position}")
             binding.uiExhibitionItem = uiExhibitionItem
-            val exhibitonHorizontalAdpater = ExhibitionHorizontalAdapter().apply {
+
+            exhibitonHorizontalAdpater = ExhibitionHorizontalAdapter().apply {
                 this.onDishItemClickListener = dishItemClickListener
             }
+
             binding.exhibitionRvHorizontal.apply {
-                adapter = exhibitonHorizontalAdpater
-                layoutManager = LinearLayoutManager(binding.root.context).also {
-                    it.orientation = LinearLayoutManager.HORIZONTAL
+                if (adapter == null) {
+                    Log.e("ExhibitionViewHolder", "horizontal adapter == null")
+                    adapter = exhibitonHorizontalAdpater
+                    layoutManager = LinearLayoutManager(binding.root.context).also {
+                        it.orientation = LinearLayoutManager.HORIZONTAL
+                    }
                 }
             }
-            exhibitonHorizontalAdpater.submitList(uiExhibitionItem.uiDishItems.toList())
+            (binding.exhibitionRvHorizontal.adapter as ExhibitionHorizontalAdapter).submitList(
+                uiExhibitionItem.uiDishItems
+            )
 
             binding.executePendingBindings()
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ExhibitionViewHolder {
+        Log.e(TAG, "onCreateViewHolder")
         val binding =
             ItemExhibitionBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return ExhibitionViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ExhibitionViewHolder, position: Int) {
-        holder.bind(currentList[position])
+        Log.e(TAG, "onBindViewHolder")
+        holder.bind(currentList[position], position)
     }
+
+    override fun onBindViewHolder(
+        holder: ExhibitionViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else {
+            if (payloads[0] == true) {
+                holder.bind(getItem(position), position)
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/adapter/ExhibitionHorizontalAdapter.kt
+++ b/app/src/main/java/com/woowahan/android10/deliverbanchan/presentation/main/exhibition/adapter/ExhibitionHorizontalAdapter.kt
@@ -1,5 +1,6 @@
 package com.woowahan.android10.deliverbanchan.presentation.main.exhibition.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
@@ -20,7 +21,7 @@ class ExhibitionHorizontalAdapter() :
     ) {
 
     companion object {
-        const val TAG = "MainDishGridAdapter"
+        const val TAG = "ExhibitionHorizontalAdapter"
         val diffUtil = object : DiffUtil.ItemCallback<UiDishItem>() {
             override fun areItemsTheSame(oldItem: UiDishItem, newItem: UiDishItem): Boolean {
                 return oldItem.hash == newItem.hash
@@ -28,6 +29,10 @@ class ExhibitionHorizontalAdapter() :
 
             override fun areContentsTheSame(oldItem: UiDishItem, newItem: UiDishItem): Boolean {
                 return newItem == oldItem
+            }
+
+            override fun getChangePayload(oldItem: UiDishItem, newItem: UiDishItem): Any? {
+                return if(oldItem.isInserted != newItem.isInserted) true else null
             }
         }
     }
@@ -41,6 +46,7 @@ class ExhibitionHorizontalAdapter() :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(uiDishItem: UiDishItem, position: Int) {
+            Log.e(TAG, "bind")
             binding.item = uiDishItem
             binding.viewLeft.isVisible = (position == 0)
             binding.viewRight.isVisible = (position == currentList.size - 1)
@@ -66,5 +72,15 @@ class ExhibitionHorizontalAdapter() :
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.bind(getItem(position), position)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else {
+            if (payloads[0] == true) {
+                holder.bind(getItem(position), position)
+            }
+        }
     }
 }


### PR DESCRIPTION
- 페이로드를 통해 기획전 화면에서 상품 장바구니 추가 시 해당 상품 카트 아이콘만 변경되도록 수정